### PR TITLE
chore(docs): fix left overs

### DIFF
--- a/docs/product-manuals/zeebe/deployment-guide/operations/resource-planning.md
+++ b/docs/product-manuals/zeebe/deployment-guide/operations/resource-planning.md
@@ -118,7 +118,7 @@ We make sure that event log segments are not deleted too early. No event log seg
 
 ### Snapshots
 
-The running state of the partition is captured periodically on the leader in a snapshot. By default, this period is every 15 minutes. This can be changed in the [configuration](../configuration/configuration.md).
+The running state of the partition is captured periodically on the leader in a snapshot. By default, this period is every 5 minutes. This can be changed in the [configuration](../configuration/configuration.md).
 
 A snapshot is a projection of all events that represent the current running state of the workflows running on the partition. It contains all active data, for example, deployed workflows, active workflow instances, and not yet completed jobs.
 

--- a/docs/product-manuals/zeebe/deployment-guide/operations/upgrade-zeebe.md
+++ b/docs/product-manuals/zeebe/deployment-guide/operations/upgrade-zeebe.md
@@ -52,7 +52,7 @@ After you verified that the upgrade was successful, we recommend to disable it a
     * Close all job workers
     * Interrupt the incoming connections to avoid user commands
 1. Wait until a snapshot is created for all partitions
-    * By default, a snapshot is created every 15 minutes
+    * By default, a snapshot is created every 5 minutes
     * Verify that a snapshot is created by looking at the [Metric](metrics.md) `zeebe_snapshot_count` on the leader and the followers
     * Note that no snapshot is created if no processing happened since the last snapshot
 1. Make a backup of the `data` folder


### PR DESCRIPTION
Removes some leftovers where 15 minutes is mentioned as snapshot period default.