### PR TITLE
clients/java: describe job worker polling and backoff

### DIFF
--- a/docs/product-manuals/clients/java-client/get-started.md
+++ b/docs/product-manuals/clients/java-client/get-started.md
@@ -385,3 +385,4 @@ From here there are several steps to take, depending on your preference:
   - [Handle variables as POJO](../java-client-examples/data-pojo.md)
 - Learn how to [write tests](testing.md)
 - Learn more about [BPMN workflows](/reference/bpmn-workflows/bpmn-primer.md) in general
+- Learn more about the Java client's [job worker](job-worker.md)

--- a/docs/product-manuals/clients/java-client/index.md
+++ b/docs/product-manuals/clients/java-client/index.md
@@ -85,6 +85,7 @@ ZeebeClient client =
 ## Next Steps
 
 - [Getting started guide](get-started.md) - Comprehensive tutorial that covers Zeebe Modeler, Operate and the Java client.
-- [Logging](logging.md) - Introduction on how to configure logging for Zeebe Client
+- [Job worker](job-worker.md) - Introduction to the Java client's job worker
+- [Logging](logging.md) - Introduction on how to configure logging for Zeebe client
 - [Writing tests](testing.md) - Introduction to writing tests that use an embedded version of the workflow engine
 - [Examples](../java-client-examples/index.md) - Collection of specific examples for different use cases

--- a/docs/product-manuals/clients/java-client/job-worker.md
+++ b/docs/product-manuals/clients/java-client/job-worker.md
@@ -1,0 +1,42 @@
+---
+id: job-worker
+title: "Job worker"
+---
+
+## Related resources
+
+- [Job worker basics](/product-manuals/concepts/job-workers.md)
+
+## The Java client's job worker
+
+The Java client provides a job worker that takes care of polling for available jobs and allows you to focus on writing code to handle the activated jobs.
+
+On `open` the job worker waits `pollInterval` milliseconds and then polls for `maxJobsActive` jobs.
+It then continues with the following schedule:
+- when a poll did not activate any jobs, it waits for `pollInterval` milliseconds and then polls for more jobs.
+- when a poll activated jobs, the worker submits each job to the job handler.
+Every time a job is handled, the worker checks whether the number of unhandled jobs have dropped below 30% of `maxJobsActive`.
+The first time that happens, it will poll for more jobs.
+- when a poll fails with an error response, a backoff strategy is applied.
+It waits for the delay provided by the `backoffSupplier` and then polls for more jobs.
+
+## Example usage
+
+- [Open a job worker](../java-client-examples/job-worker-open.md)
+
+## Backoff configuration
+
+When a poll fails with an error response, the job worker applies a backoff strategy.
+It waits for some time, after which it polls again for more jobs.
+This gives a Zeebe cluster some time to recover from a failure.
+In some cases, you may want to configure this backoff strategy to better fit your situation.
+
+The retry delay (i.e. the time the job worker waits after an error before the next poll for new jobs) is provided by the [`BackoffSupplier`](https://github.com/zeebe-io/zeebe/blob/develop/clients/java/src/main/java/io/zeebe/client/api/worker/BackoffSupplier.java).
+You can replace it using the `.backoffSupplier()` method on the [`JobWorkerBuilder`](https://github.com/zeebe-io/zeebe/blob/develop/clients/java/src/main/java/io/zeebe/client/api/worker/JobWorkerBuilderStep1.java).
+By default, the job worker uses an exponential backoff implementation, which can you can configure using `BackoffSupplier.newBackoffBuilder()`.
+
+The backoff strategy is especially useful for dealing with the `GRPC_STATUS_RESOURCE_EXHAUSTED` error response (see [gRPC Technical Error Handling](../../../reference/grpc#technical-error-handling)).
+This error code indicates the Zeebe cluster is currently under too much load and has decided to reject this request.
+By backing off, the job worker helps Zeebe by reducing the load.
+Note, that Zeebe's [backpressure mechanism](../../zeebe/deployment-guide/operations/backpressure) can also be configured.
+


### PR DESCRIPTION
Adds a description of the java client's job worker polling behaviour and how to configure its backoff strategy.

closes #183 