### PR TITLE
chore(feel): update the FEEL reference for version 1.13.1

### DIFF
--- a/docs/reference/feel/builtin-functions/feel-built-in-functions-boolean.md
+++ b/docs/reference/feel/builtin-functions/feel-built-in-functions-boolean.md
@@ -1,9 +1,9 @@
 ---
 id: feel-built-in-functions-boolean
-title: Boolean functions
+title: Boolean Functions
 ---
 
-## `not()`
+## not()
 
 * parameters:
   * `negand`: boolean
@@ -14,7 +14,7 @@ not(true)
 // false
 ```
 
-## `is defined()`
+## is defined()
 
 Checks if a given value is defined or not. A value is defined if it exists, and it is an instance of one of the FEEL data types including `null`.
 

--- a/docs/reference/feel/builtin-functions/feel-built-in-functions-context.md
+++ b/docs/reference/feel/builtin-functions/feel-built-in-functions-context.md
@@ -1,9 +1,9 @@
 ---
 id: feel-built-in-functions-context
-title: Context functions
+title: Context Functions
 ---
 
-## `get value()`
+## get value()
 
 Returns the value of the context entry with the given key.
 
@@ -17,7 +17,7 @@ get value({foo: 123}, "foo")
 // 123
 ```
 
-## `get entries()`
+## get entries()
 
 Returns the entries of the context as list of key-value-pairs.
 
@@ -28,4 +28,36 @@ Returns the entries of the context as list of key-value-pairs.
 ```js
 get entries({foo: 123})
 // [{key: "foo", value: 123}]
+```
+
+## put()
+
+Add the given key and value to a context. Returns a new context that includes the entry. It might override an existing entry of the context.  
+
+Returns `null` if the value is not defined.
+
+* parameters:
+  * `context`: context
+  * `key`: string
+  * `value`: any
+* result: context  
+
+```js
+put({x:1}, "y", 2)
+// {x:1, y:2}
+```
+
+## put all()
+
+Union the given contexts (two or more). Returns a new context that includes all entries of the given contexts. It might override context entries if the keys are equal. The entries are overridden in the same order as the contexts are passed in the method.    
+
+Returns `null` if one of the values is not a context.
+
+* parameters:
+  * `contexts`: contexts as varargs
+* result: context  
+
+```js
+put all({x:1}, {y:2})
+// {x:1, y:2}
 ```

--- a/docs/reference/feel/builtin-functions/feel-built-in-functions-conversion.md
+++ b/docs/reference/feel/builtin-functions/feel-built-in-functions-conversion.md
@@ -1,11 +1,11 @@
 ---
 id: feel-built-in-functions-conversion
-title: Conversion functions
+title: Conversion Functions
 ---
 
 Convert a value into a different type.
 
-## `date()`
+## date()
 
 * parameters:
   * `from`: string / date-time
@@ -23,7 +23,7 @@ date(2012, 12, 25)
 // date("2012-12-25")
 ```
 
-## `time()`
+## time()
 
 * parameters:
   * `from`: string / date-time
@@ -45,7 +45,7 @@ time(14, 30, 0, duration("PT1H"))
 // time("15:30:00")
 ```
 
-## `date and time()`
+## date and time()
 
 * parameters:
   * `date`: date / date-time
@@ -64,7 +64,7 @@ date and time(birthday)
 // date and time("2018-04-29T009:30:00")
 ```
 
-## `duration()`
+## duration()
 
 * parameters:
   * `from`: string
@@ -78,7 +78,7 @@ duration(age)
 // duration("P32Y")
 ```
 
-## `years and months duration()`
+## years and months duration()
 
 * parameters:
   * `from`: date
@@ -90,7 +90,7 @@ years and months duration(date("2011-12-22"), date("2013-08-24"))
 // duration("P1Y8M")
 ```
 
-## `number()`
+## number()
 
 * parameters:
   * `from`: string
@@ -101,7 +101,7 @@ number("1500.5")
 // 1500.5
 ```
 
-## `string()`
+## string()
 
 * parameters:
   * `from`: any
@@ -113,4 +113,23 @@ string(1.1)
 
 string(date("2012-12-25"))
 // "2012-12-25"
+```
+
+## context()
+
+Constructs a context of the given list of key-value pairs. It is the reverse function to [get entries()](feel-built-in-functions-context.md#get-entries).
+
+Each key-value pair must be a context with two entries: `key` and `value`. The entry with name `key` must have a value of the type `string`.
+
+It might override context entries if the keys are equal. The entries are overridden in the same order as the contexts in the given list.    
+
+Returns `null` if one of the entries is not a context, or if a context doesn't contain the required entries.
+
+* parameters:
+  * `entries`: list of contexts 
+* result: context  
+
+```js
+context([{"key":"a", "value":1}, {"key":"b", "value":2}])
+// {a:1, b:2}
 ```

--- a/docs/reference/feel/builtin-functions/feel-built-in-functions-list.md
+++ b/docs/reference/feel/builtin-functions/feel-built-in-functions-list.md
@@ -1,9 +1,9 @@
 ---
 id: feel-built-in-functions-list
-title: List functions
+title: List Functions
 ---
 
-## `list contains()`
+## list contains()
 
 * parameters:
   * `list`: list
@@ -15,7 +15,7 @@ list contains([1,2,3], 2)
 // true
 ```
 
-## `count()`
+## count()
 
 * parameters:
   * `list`: list
@@ -26,7 +26,7 @@ count([1,2,3])
 // 3
 ```
 
-## `min()`
+## min()
 
 * parameters:
   * `list`: list of numbers
@@ -41,7 +41,7 @@ min(1,2,3)
 // 1
 ```
 
-## `max()`
+## max()
 
 * parameters:
   * `list`: list of numbers
@@ -56,7 +56,7 @@ min(1,2,3)
 // 3
 ```
 
-## `sum()`
+## sum()
 
 * parameters:
   * `list`: list of numbers
@@ -71,7 +71,7 @@ min(1,2,3)
 // 6
 ```
 
-## `product()`
+## product()
 
 * parameters:
   * `list`: list of numbers
@@ -86,7 +86,7 @@ product(2, 3, 4)
 // 24
 ```
 
-## `mean()`
+## mean()
 
 Returns the arithmetic mean (i.e. average).
 
@@ -103,7 +103,7 @@ mean(1,2,3)
 // 2
 ```
 
-## `median()`
+## median()
 
 Returns the median element of the list of numbers.
 
@@ -120,7 +120,7 @@ median([6, 1, 2, 3])
 // 2.5
 ```
 
-## `stddev()`
+## stddev()
 
 Returns the standard deviation.
 
@@ -137,7 +137,7 @@ stddev([2, 4, 7, 5])
 // 2.0816659994661326
 ```
 
-## `mode()`
+## mode()
 
 Returns the mode of the list of numbers.
 
@@ -154,7 +154,7 @@ mode([6, 1, 9, 6, 1])
 // [1, 6]
 ```
 
-## `and()` / `all()`
+## and() / all()
 
 * parameters:
   * `list`: list of booleans
@@ -169,7 +169,7 @@ and(false,null,true)
 // false
 ```
 
-## `or(`) / `any()`
+## or() / any()
 
 * parameters:
   * `list`: list of booleans
@@ -184,7 +184,7 @@ or(false,null,true)
 // true
 ```
 
-## `sublist()`
+## sublist()
 
 * parameters:
   * `list`: list
@@ -200,7 +200,7 @@ sublist([1,2,3], 1, 2)
 // [1,2]
 ```
 
-## `append()`
+## append()
 
 * parameters:
   * `list`: list
@@ -212,7 +212,7 @@ append([1], 2, 3)
 // [1,2,3]
 ```
 
-## `concatenate()`
+## concatenate()
 
 * parameters:
   * `lists`: lists as varargs
@@ -226,7 +226,7 @@ concatenate([1],[2],[3])
 // [1,2,3]
 ```
 
-## `insert before()`
+## insert before()
 
 * parameters:
   * `list`: list
@@ -239,7 +239,7 @@ insert before([1,3],1,2)
 // [1,2,3]
 ```
 
-## `remove()`
+## remove()
 
 * parameters:
   * `list`: list
@@ -251,7 +251,7 @@ remove([1,2,3], 2)
 // [1,3]
 ```
 
-## `reverse()`
+## reverse()
 
 * parameters:
   * `list`: list
@@ -262,7 +262,7 @@ reverse([1,2,3])
 // [3,2,1]
 ```
 
-## `index of()`
+## index of()
 
 * parameters:
   * `list`: list
@@ -274,7 +274,7 @@ index of([1,2,3,2],2)
 // [2,4]
 ```
 
-## `union()`
+## union()
 
 * parameters:
   * `lists`: lists as varargs
@@ -285,7 +285,7 @@ union([1,2],[2,3])
 // [1,2,3]
 ```
 
-## `distinct values()`
+## distinct values()
 
 * parameters:
   * `list`: list
@@ -296,7 +296,7 @@ distinct values([1,2,3,2,1])
 // [1,2,3]
 ```
 
-## `flatten()`
+## flatten()
 
 * parameters:
   * `list`: list
@@ -307,7 +307,7 @@ flatten([[1,2],[[3]], 4])
 // [1,2,3,4]
 ```
 
-## `sort()`
+## sort()
 
 * parameters:
   * `list`: list 

--- a/docs/reference/feel/builtin-functions/feel-built-in-functions-numeric.md
+++ b/docs/reference/feel/builtin-functions/feel-built-in-functions-numeric.md
@@ -1,9 +1,9 @@
 ---
 id: feel-built-in-functions-numeric
-title: Numeric functions
+title: Numeric Functions
 ---
 
-## `decimal()`
+## decimal()
 
 Round the given number at the given scale using the given rounding mode. If no rounding mode is passed in then it uses `HALF_EVEN` as default. 
 
@@ -24,7 +24,7 @@ decimal(2.5, 0, "half_up")
 // 3
 ```
 
-## `floor()`
+## floor()
 
 * parameters:
   * `n`: number
@@ -38,7 +38,7 @@ floor(-1.5)
 // -2
 ```
 
-## `ceiling()`
+## ceiling()
 
 * parameters:
   * `n`: number
@@ -52,7 +52,7 @@ floor(-1.5)
 // -1
 ```
 
-## `abs()`
+## abs()
 
 * parameters:
   * `number`: number
@@ -66,7 +66,7 @@ abs(-10)
 // 10
 ```
 
-## `modulo()`
+## modulo()
 
 Returns the remainder of the division of dividend by divisor.
 
@@ -80,7 +80,7 @@ modulo(12, 5)
 // 2
 ```
 
-## `sqrt()`
+## sqrt()
 
 Returns the square root.
 
@@ -93,7 +93,7 @@ sqrt(16)
 // 4
 ```
 
-## `log()`
+## log()
 
 Returns the natural logarithm (base e) of the number.
 
@@ -106,7 +106,7 @@ log(10)
 // 2.302585092994046
 ```
 
-## `exp()`
+## exp()
 
 Returns the Euler’s number e raised to the power of number .
 
@@ -119,7 +119,7 @@ exp(5)
 // 148.4131591025766
 ```
 
-## `odd()`
+## odd()
 
 * parameters:
   * `number`: number
@@ -130,7 +130,7 @@ odd(5)
 // true
 ```
 
-## `even()`
+## even()
 
 * parameters:
   * `number`: number

--- a/docs/reference/feel/builtin-functions/feel-built-in-functions-string.md
+++ b/docs/reference/feel/builtin-functions/feel-built-in-functions-string.md
@@ -1,9 +1,9 @@
 ---
 id: feel-built-in-functions-string
-title: String functions
+title: String Functions
 ---
 
-## `substring()`
+## substring()
 
 * parameters:
   * `string`: string
@@ -19,7 +19,7 @@ substring("foobar",3,3)
 // "oba"
 ```
 
-## `string length()`
+## string length()
 
 * parameters:
   * `string`: string
@@ -30,7 +30,7 @@ string length("foo")
 // 3
 ```
 
-## `upper case()`
+## upper case()
 
 * parameters:
   * `string`: string
@@ -41,7 +41,7 @@ upper case("aBc4")
 // "ABC4"
 ```
 
-## `lower case()`
+## lower case()
 
 * parameters:
   * `string`: string
@@ -52,7 +52,7 @@ lower case("aBc4")
 // "abc4"
 ```
 
-## `substring before()`
+## substring before()
 
 * parameters:
   * `string`: string
@@ -64,7 +64,7 @@ substring before("foobar", "bar")
 // "foo"
 ```
 
-## `substring after()`
+## substring after()
 
 * parameters:
   * `string`: string
@@ -76,7 +76,7 @@ substring after("foobar", "ob")
 // "ar"
 ```
 
-## `contains()`
+## contains()
 
 * parameters:
   * `string`: string
@@ -88,7 +88,7 @@ contains("foobar", "of")
 // false
 ```
 
-## `starts with()`
+## starts with()
 
 * parameters:
   * `input`: string
@@ -100,7 +100,7 @@ starts with("foobar", "fo")
 // true
 ```
 
-## `ends with()`
+## ends with()
 
 * parameters:
   * `input`: string
@@ -112,7 +112,7 @@ ends with("foobar", "r")
 // true
 ```
 
-## `matches()`
+## matches()
 
 * parameters:
   * `input`: string
@@ -124,7 +124,7 @@ matches("foobar", "^fo*bar")
 // true
 ```
 
-## `replace()`
+## replace()
 
 * parameters:
   * `input`: string
@@ -141,7 +141,7 @@ replace("0123456789", "(\d{3})(\d{3})(\d{4})", "($1) $2-$3")
 // "(012) 345-6789"
 ```
 
-## `split()`
+## split()
 
 * parameters:
   * `string`: string

--- a/docs/reference/feel/builtin-functions/feel-built-in-functions-temporal.md
+++ b/docs/reference/feel/builtin-functions/feel-built-in-functions-temporal.md
@@ -1,9 +1,9 @@
 ---
 id: feel-built-in-functions-temporal
-title: Temporal functions
+title: Temporal Functions
 ---
 
-## `now()`
+## now()
 
 Returns the current date and time including the timezone.
 
@@ -15,7 +15,7 @@ now()
 // date and time("2020-07-31T14:27:30@Europe/Berlin")
 ```
 
-## `today()`
+## today()
 
 Returns the current date.
 
@@ -27,7 +27,7 @@ today()
 // date("2020-07-31")
 ```
 
-## `day of week()`
+## day of week()
 
 Returns the day of the week according to the Gregorian calendar. Note that it returns always the english name of the day.
 
@@ -40,7 +40,7 @@ day of week(date("2019-09-17"))
 // "Tuesday"
 ```
 
-## `day of year()`
+## day of year()
 
 Returns the Gregorian number of the day within the year.
 
@@ -53,7 +53,7 @@ day of year(date("2019-09-17"))
 // 260
 ```
 
-## `week of year()`
+## week of year()
 
 Returns the Gregorian number of the week within the year, according to ISO 8601.
 
@@ -66,7 +66,7 @@ week of year(date("2019-09-17"))
 // 38
 ```
 
-## `month of year()`
+## month of year()
 
 Returns the month of the week according to the Gregorian calendar. Note that it returns always the english name of the month.
 

--- a/docs/reference/feel/language-guide/feel-data-types.md
+++ b/docs/reference/feel/language-guide/feel-data-types.md
@@ -1,6 +1,6 @@
 ---
 id: feel-data-types
-title: Data types
+title: Data Types
 ---
 
 A value can have one of the following types.
@@ -32,6 +32,8 @@ A whole or floating point number.
 
 ### String
 
+A sequence of characters enclosed in double quotes `"`. The sequence can also contain escaped characters starting with `\` (e.g. `\'`, `\"`, `\\`, `\n`, `\r`, `\t`, unicode like `\u269D` or `\U101EF`).
+
 * Java Type: `java.lang.String`
 
 ```js
@@ -39,6 +41,8 @@ A whole or floating point number.
 ```
 
 ### Boolean
+
+A boolean value. It is either true or false. 
 
 * Java Type: `java.lang.Boolean`
 
@@ -48,6 +52,8 @@ false
 ```
 
 ### Date 
+
+A date value without a time component.
 
 * Format: `yyyy-MM-dd`.
 * Java Type: `java.time.LocalDate`

--- a/docs/reference/feel/language-guide/feel-expression.md
+++ b/docs/reference/feel/language-guide/feel-expression.md
@@ -10,9 +10,9 @@ An expression can contain literals, operators and function calls.
 A single value of one of the [types](feel-data-types.md).
 
 ```js
-null;
-21;
-("valid");
+null
+21
+"valid"
 ```
 
 ### Path Expression
@@ -20,13 +20,13 @@ null;
 Access a value by its name/path. For example, a given variable from the input/context.
 
 ```js
-x + y;
+x + y
 ```
 
 If the value is a context (or data object/POJO) then the inner values can be accessed by `context.key`.
 
 ```js
-x.y;
+x.y
 // return 1 if x is {y: 1}
 ```
 
@@ -61,120 +61,119 @@ If the name or path contains any special character (e.g. whitespace, dash, etc.)
 
 ### Addition
 
-- supported types: number, string, day-time-duration, year-month-duration
+* supported types: number, string, day-time-duration, year-month-duration
 
 ```js
-2 + 3;
+2 + 3
 // 5
 
-"foo" + "bar";
+"foo" + "bar"
 // "foobar"
 
-duration("P1D") + duration("PT6H");
+duration("P1D") + duration("PT6H")
 // duration("P1DT6H")
 ```
 
-### Subtraction
+### Subtraction 
 
-- supported types: number, time, date-time, day-time-duration, year-month-duration
+* supported types: number, time, date-time, day-time-duration, year-month-duration
 
 ```js
-5 - 3;
+5 - 3
 // 2
 
-time("10:30:00") - time("09:00:00");
+time("10:30:00") - time("09:00:00")
 // duration("PT1H30M")
 
-time("10:30:00") - duration("PT1H");
+time("10:30:00") - duration("PT1H") 
 // time("09:30:00")
 ```
 
 ### Multiplication
 
-- supported types: number, day-time-duration, year-month-duration
+* supported types: number, day-time-duration, year-month-duration
 
 ```js
-5 * 3;
+5 * 3        
 // 15
 
-3 * duration("P2Y");
-// duration("P6Y")
+3 * duration("P2Y")      
+// duration("P6Y") 
 ```
 
-### Division
+### Division 
 
-- supported types: number, day-time-duration, year-month-duration
+* supported types: number, day-time-duration, year-month-duration
 
 ```js
-6 / 2;
+6 / 2  
 // 3
 
-duration("P1Y") / 2;
+duration("P1Y") / 2 
 // duration("P6M")
 
-duration("P1Y") / duration("P1M");
+duration("P1Y") / duration("P1M")
 // 12
 ```
 
-### Exponentiation
+### Exponentiation 
 
-- supported types: number
+* supported types: number
 
 ```js
-2 ** 3;
+2 ** 3   
 // 8
 ```
 
 ### Comparison
 
-| operator              | symbol            | example             |
-| --------------------- | ----------------- | ------------------- |
-| equal to              | `=`               | `x = "valid"`       |
-| not equal to          | `!=`              | `x != "valid"`      |
-| less than             | `<`               | `< 10`              |
-| less than or equal    | `<=`              | `<= 10`             |
-| greater than          | `>`               | `> 10`              |
-| greater than or equal | `>=`              | `>= 10`             |
-| between               | `between _ and _` | `x between 3 and 9` |
+| operator | symbol | example |
+|----------|-----------------|---------|
+| equal to | `=` | `x = "valid"` |
+| not equal to | `!=` | `x != "valid"` |
+| less than | `<`  | `< 10` |
+| less than or equal | `<=` | `<= 10` |
+| greater than | `>` | `> 10` |
+| greater than or equal | `>=` | `>= 10` |
+| between | `between _ and _` | `x between 3 and 9` |
 
-The operators less than, greater than, and between are only supported for:
-
-- number
-- date
-- time
-- date-time
-- year-month-duration
-- day-time-duration
-
-Any value can be compared with `null` to check if it is equal to `null`, or if it exists. Comparing `null` to a value different from `null` results in `false`. It returns `true` if the value, or the context entry (e.g. the property of a variable) is `null` or doesn't exist. The built-in function [is defined()](../builtin-functions/feel-built-in-functions-boolean.md#is-defined) can be used to differentiate between a value that is `null` and a value that doesn't exist.
+The operators less than, greater than, and between are only supported for: 
+  * number
+  * date
+  * time
+  * date-time
+  * year-month-duration
+  * day-time-duration 
+  
+Any value can be compared with `null` to check if it is equal to `null`, or if it exists. Comparing `null` to a value different from `null` results in `false`. It returns `true` if the value, or the context entry (e.g. the property of a variable) is `null` or doesn't exist. The built-in function [is defined()](../builtin-functions/feel-built-in-functions-boolean.md#is-defined) can be used to differentiate between a value that is `null` and a value that doesn't exist. 
 
 ```js
-null = null;
+null = null
 // true
 
-"foo" = null;
+"foo" = null
 // false
 
-x = null;
+x = null
 // true - if "x" is null or doesn't exist
 
-x.y = null;
-// true - if "x" is null, "x" doesn't exist,
-//           "y" is null, or "x" has no property "y"
-```
+x.y = null
+// true - if "x" is null, "x" doesn't exist, 
+//           "y" is null, or "x" has no property "y" 
+```  
 
-### Disjunction and conjunction
+### Disjunction and Conjunction
 
 Combine two boolean values.
 
 ```js
-true and true
+true and true   
 // true
 
-true and false
+true and false        
 // false
 
-true and null
+true and null        
 // null
 
 false and null
@@ -182,141 +181,131 @@ false and null
 ```
 
 ```js
-true or false
+true or false   
 // true
 
-false or false
+false or false  
 // false
 
-true or null
+true or null   
 // true
 
-false or null
+false or null  
 // null
 ```
 
-### If expression
+### If Expression
 
 ```js
 if (x < 5) then "low" else "high"
 ```
 
-### For expressions
+### For Expressions
 
 Iterate over a list and apply an expression (i.e. aka `map`). The result is again a list.
 
 ```js
-for x in [1,2] return x * 2
+for x in [1,2] return x * 2 
 // [2,4]
 ```
 
 Iterate over multiple lists.
 
 ```js
-for x in [1,2], y in [3,4] return x * y
+for x in [1,2], y in [3,4] return x * y  
 // [3,4,6,8]
 ```
 
 Iterate over a range - forward or backward.
 
 ```js
-for x in 1..3 return x * 2
+for x in 1..3 return x * 2                  
 // [2,4,6]
 
-for x in 3..1 return x * 2
+for x in 3..1 return x * 2       
 // [6,4,2]
 ```
 
-The previous results of the iterator can be accessed by the variable `partial`.
+The previous results of the iterator can be accessed by the variable `partial`. 
 
 ```js
-for x in 1..5 return x + sum(partial)
+for x in 1..5 return x + sum(partial)       
 // [1,3,7,15,31]
 ```
 
-### Some/every expression
+### Some/Every Expression
 
 Test if at least one element of the list satisfies the expression.
 
 ```js
-some x in [1,2,3] satisfies x > 2
+some x in [1,2,3] satisfies x > 2         
 // true
 
-some x in [1,2,3] satisfies x > 3
+some x in [1,2,3] satisfies x > 3   
 // false
 
-some x in [1,2], y in [2,3] satisfies x < y
+some x in [1,2], y in [2,3] satisfies x < y  
 // true
 ```
 
 Test if all elements of the list satisfies the expression.
 
 ```js
-every x in [1,2,3] satisfies x >= 1
+every x in [1,2,3] satisfies x >= 1   
 // true
 
-every x in [1,2,3] satisfies x >= 2
+every x in [1,2,3] satisfies x >= 2     
 // false
 
-every x in [1,2], y in [2,3] satisfies x < y
+every x in [1,2], y in [2,3] satisfies x < y 
 // false
 ```
 
-### Filter expression
+### Filter Expression
 
 Filter a list of elements by an expression. The expression can access the current element by `item`. The result is a list again.
 
 ```js
-[1, 2, 3, 4][item > 2];
+[1,2,3,4][item > 2]   
 // [3,4]
 ```
 
 An element of a list can be accessed by its index. The index starts at `1`. A negative index starts at the end by `-1`.
 
 ```js
-[1, 2, 3, 4][1][
-  // 1
+[1,2,3,4][1]           
+// 1
 
-  (1, 2, 3, 4)
-][4][
-  // 4
+[1,2,3,4][4]                                   
+// 4
 
-  (1, 2, 3, 4)
-][-1][
-  // 4
+[1,2,3,4][-1]                                  
+// 4
 
-  (1, 2, 3, 4)
-][-2][
-  // 3
+[1,2,3,4][-2]                                  
+// 3
 
-  (1, 2, 3, 4)
-][5];
+[1,2,3,4][5]                                   
 // null
 ```
 
 If the elements are contextes then the nested value of the current element can be accessed directly by its name.
 
 ```js
-[
-  { a: "foo", b: 5 },
-  { a: "bar", b: 10 },
-][b > 7];
+[ {a: "foo", b: 5},  {a: "bar", b: 10} ][b > 7] 
 // {a : "bar", b: 10}
 ```
 
 The nested values of a specific key can be extracted by `.key`.
 
 ```js
-[
-  { a: "foo", b: 5 },
-  { a: "bar", b: 10 },
-].a;
+[ {a : "foo", b: 5 }, {a: "bar", b: 10} ].a     
 // ["foo", "bar"]
 ```
 
-### Evaluate a unary tests
+### Evaluate a Unary Tests
 
-Evaluates a [unary tests expression](feel-unary-tests) with the given value.
+Evaluates a [unary-tests expression](feel-unary-tests) with the given value. 
 
 ```js
 x in (2..4)
@@ -324,15 +313,15 @@ x in (2..4)
 x in < 3
 ```
 
-### Instance-Of expression
+### Instance-Of Expression
 
 Checks the type of the value.
 
 ```js
-"foo" instance of number
+"foo" instance of number                      
 // false
 
-"bar" instance of string
+"bar" instance of string                            
 // true
 ```
 
@@ -341,12 +330,12 @@ Checks the type of the value.
 Invoke a user-defined or built-in function by its name. The arguments can be passed positional or named.
 
 ```js
-add(1, 2);
+add(1,2)
 // or
-add((x: 1), (y: 2));
+add(x:1, y:2)
 ```
 
-A function (body) can be defined using `function(arguments) expression`. For example, inside a context.
+A function (body) can be defined using `function(arguments) expression`. For example, inside a context. 
 
 ```js
 {
@@ -354,20 +343,20 @@ A function (body) can be defined using `function(arguments) expression`. For exa
 }
 ```
 
-### Special properties
+### Special Properties
 
 Values of type date, time, date-time and duration have special properties to access their individual parts.
 
 ```js
-date("2017-03-10").year
-date("2017-03-10").month
+date("2017-03-10").year                   
+date("2017-03-10").month                
 date("2017-03-10").day
 date("2017-03-10").weekday
 
-time("11:45:30+02:00").hour
-time("11:45:30+02:00").minute
-time("11:45:30+02:00").second
-time("11:45:30+02:00").time offset
+time("11:45:30+02:00").hour            
+time("11:45:30+02:00").minute         
+time("11:45:30+02:00").second        
+time("11:45:30+02:00").time offset   
 
 date and time("2017-03-10T11:45:30+02:00").year
 date and time("2017-03-10T11:45:30+02:00").month
@@ -379,11 +368,11 @@ date and time("2017-03-10T11:45:30+02:00").second
 date and time("2017-03-10T11:45:30+02:00").time offset
 date and time("2017-03-10T11:45:30+02:00").timezone
 
-duration("P2Y3M").years
-duration("P2Y3M").months
+duration("P2Y3M").years                  
+duration("P2Y3M").months               
 
-duration("P1DT2H10M30S").days
-duration("P1DT2H10M30S").hours
-duration("P1DT2H10M30S").minutes
-duration("P1DT2H10M30S").seconds
+duration("P1DT2H10M30S").days      
+duration("P1DT2H10M30S").hours     
+duration("P1DT2H10M30S").minutes 
+duration("P1DT2H10M30S").seconds 
 ```

--- a/docs/reference/feel/language-guide/feel-unary-tests.md
+++ b/docs/reference/feel/language-guide/feel-unary-tests.md
@@ -1,13 +1,13 @@
 ---
 id: feel-unary-tests
-title: Unary tests
+title: Unary-Tests
 ---
 
-Unary tests can be used only for input entries of a decision table. They are a special kind of expression with additional operators. The operators get the value of the input expression implicitly as the first argument. 
+Unary-Tests can be used only for input entries of a decision table. They are a special kind of expression with additional operators. The operators get the value of the input expression implicitly as the first argument. 
 
 The result of the expression must be either `true` or `false`.
 
-A unary test expression is `true` if one of the following conditions is fulfilled:
+An unary-tests expression is `true` if one of the following conditions is fulfilled:
 * the expression evaluates to `true` when the input value is applied to it
 * the expression evaluates to a list and the input value is equal to at least one of the values in that list
 * the expression evaluates to a value and the input value is equal to that value 

--- a/docs/reference/feel/what-is-feel.md
+++ b/docs/reference/feel/what-is-feel.md
@@ -5,28 +5,28 @@ title: What is FEEL?
 
 FEEL (Friendly Enough Expression Language) is a part of the [DMN specification](http://www.omg.org/spec/DMN/) of the OMG. It is designed to write expressions for decision tables and literal expressions in a simple way what can easily understand by business professionals and developers.
 
-## Unary tests vs. expression
+## Unary Tests vs. Expression
 
-FEEL has two entry points: unary-tests and expressions.
+FEEL has two entry points: unary-tests and expressions. 
 
-### Unary tests
+### Unary Tests
 
-Unary-tests can be used only for input entries of a decision table. They are a special kind of expression with a different grammar. The expression gets the value of the input expression implicitly as the first argument. The result of the expression must be either `true` or `false`.
+Unary-Tests can be used only for input entries of a decision table. They are a special kind of expression with a different grammar. The expression gets the value of the input expression implicitly as the first argument. The result of the expression must be either `true` or `false`.
 
 Examples:
 
 ```js
-< 7
+< 7                                                 
 // input less than 7
 
-not(2,4)
+not(2,4)                                            
 // input is not 2 or 4
 
-[date("2015-09-17")..date("2015-09-19")]
+[date("2015-09-17")..date("2015-09-19")]            
 // input is between '2015-09-17' and '2015-09-19'
 
-<= duration("P1D")
-// input is less or equal one day
+<= duration("P1D")                                  
+// input is less or equal one day    
 ```
 
 ### Expression
@@ -36,13 +36,13 @@ Expressions can be used everywhere, e.g. in a decision table as input expression
 Examples:
 
 ```js
-applicant.monthly.income * 12
+applicant.monthly.income * 12                                           
 
-if applicant.maritalStatus in ("M","S") then "valid" else "not valid"
+if applicant.maritalStatus in ("M","S") then "valid" else "not valid"    
 
-sum( [applicant.monthly.repayments, applicant.monthly.expenses] )
+sum( [applicant.monthly.repayments, applicant.monthly.expenses] )        
 
-sum( credit_history[record_date > date("2011-01-01")].weight )
+sum( credit_history[record_date > date("2011-01-01")].weight )           
 
-some ch in credit_history satisfies ch.event = "bankruptcy"
+some ch in credit_history satisfies ch.event = "bankruptcy"      
 ```


### PR DESCRIPTION
* Zeebe has updated the dependency `feel-engine` to `1.13.1` (camunda-cloud/zeebe#6586)
* **copy** the docs from the repository and replace the existing docs
* replace the local changes by the origin docs (e.g. code markers for function headlines, tailing semicolons in code snippets, etc.) to improve the maintainability (goal: just copy the docs without additional changes)
* no new content has been added compared to the origin docs