### PR TITLE
Document system clock/backpressure issues

### DIFF
--- a/docs/product-manuals/zeebe/deployment-guide/operations/backpressure.md
+++ b/docs/product-manuals/zeebe/deployment-guide/operations/backpressure.md
@@ -93,3 +93,7 @@ Higher the value of _rttTolerance_, higher deviations are tolerated that results
 
 If a lot of requests are rejected due to backpressure, it might indicate that the processing capacity of the cluster is not enough to handle the expected throughput.
 If this is the expected workload, then you might consider a different configuration for the cluster such as provisioning more resources and, increasing the number of nodes and partitions.
+
+## Potential Issues
+
+The rate limiter used by Zeebe to implement backpressure may use `System.nanoTime()` to measure the RTT of requests. In some systems, we've observed that consecutive calls to this method can return equal or even decreasing values. [Low clock resolution](https://shipilev.net/blog/2014/nanotrusting-nanotime) and [monotonicity](https://bugs.openjdk.java.net/browse/JDK-6458294) [issues](https://stackoverflow.com/questions/3657289/linux-clock-gettimeclock-monotonic-strange-non-monotonic-behavior) are some of the most likely culprits of this. If this happens, it's recommended to configure the backpressure to use the 'fixed' algorithm. Without a clock with sufficient resolution, adaptive backpressure algorithms are not useful.


### PR DESCRIPTION
Documents issues caused by problematic system clocks