### PR TITLE
Add Public API page

### DIFF
--- a/docs/reference/overview.md
+++ b/docs/reference/overview.md
@@ -8,6 +8,7 @@ slug: /reference/
 This section contains general reference material for Camunda Cloud, including API references.
 
 ## APIs
+- [Public API](public-api.md)
 - [Console API clients](cloud-console-api-clients.md)
 - [Console API (REST)](cloud-console-api-reference.md)
 - [Zeebe API (gRPC)](grpc.md)

--- a/docs/reference/public-api.md
+++ b/docs/reference/public-api.md
@@ -1,0 +1,32 @@
+---
+id: public-api
+title: "Public API"
+---
+
+Camunda Cloud provides a public API. This section covers the definition of the public API and backwards compatibility for version updates.
+
+## Backwards Compatibility for Public API
+
+Camunda Cloud versioning scheme follows the `MAJOR.MINOR.PATCH` pattern put forward by [Semantic Versioning](https://semver.org/). Camunda Cloud will
+maintain public API backwards compatibility for `MINOR` version updates. Example: Update from version `1.0.x` to `1.1.y` will not break the public API.
+
+To learn more about our release cycle, please refer to our [release
+policy](/reference/release-policy.md).
+
+
+## Definition of Public API
+
+Camunda Cloud public API is limited to the following items:
+
+### [Zeebe Client Java API](/product-manuals/clients/java-client/index.md)
+
+All non-implementation Java packages (package name does not contain `impl`) of the following maven modules.
+
+- `io.camunda:zeebe-client-java`
+
+
+## Other APIs and Client
+
+Although we cannot guarentee backwards comptability of others APIs and Clients 
+at this moment of time, we aim to offer backwards compatibility still on a best
+effort basis.

--- a/sidebars.js
+++ b/sidebars.js
@@ -268,7 +268,8 @@ module.exports = {
     },
   ],
   Reference: [
-    "reference/overview",  
+    "reference/overview",
+    "reference/public-api",
     "reference/cloud-console-api-clients",
     "reference/cloud-console-api-reference",
     "reference/grpc",


### PR DESCRIPTION
Add a page to document the public API of Camunda Cloud. Public API is defined as an API which we guarantee backwards compatibility. At the moment we agreed that for 1.0 we only see the Java Client API as public API.

I choose to put it in the reference section as I didn't see fit in other sections, and wasn't sure how a new section could look like. Happy to take suggestions. 