### PR TITLE
Updating Helm Repository URLs after renaming

### DIFF
--- a/docs/product-manuals/zeebe/deployment-guide/kubernetes/helm/index.md
+++ b/docs/product-manuals/zeebe/deployment-guide/kubernetes/helm/index.md
@@ -8,11 +8,11 @@ sidebar_label: "Overview"
 
 This section covers the fundamentals of how to run Zeebe in Kubernetes. There are several alternatives on how to deploy applications to a Kubernetes cluster, but the following sections are using Helm charts to deploy a set of components into your cluster.
 
-Helm allows you to choose exactly what chart (set of components) do you want to install and how these components needs to be configured. These Helm charts are continuously being improved and released to the [Zeebe Helm Chart Repository](http://helm.zeebe.io)
+Helm allows you to choose exactly what chart (set of components) do you want to install and how these components needs to be configured. These Helm charts are continuously being improved and released to the [Zeebe Helm Chart Repository](http://helm.camunda.io)
 
-You are free to choose your Kubernetes provider, our Helm charts are not cloud provider specific and we encourage [reporting issues](http://github.com/zeebe-io/zeebe-full-helm/issues) if you find them.
+You are free to choose your Kubernetes provider, our Helm charts are not cloud provider specific and we encourage [reporting issues](http://github.com/camunda-community-hub/zeebe-full-helm/issues) if you find them.
 
-You can also join us on [Slack](https://zeebe-slack-invite.herokuapp.com/).
+You can also join us on [Slack](https://camunda-cloud.slack.com/).
 
 This chapter is divided in the following sections:
 

--- a/docs/product-manuals/zeebe/deployment-guide/kubernetes/helm/installing-helm.md
+++ b/docs/product-manuals/zeebe/deployment-guide/kubernetes/helm/installing-helm.md
@@ -9,15 +9,15 @@ title: "Zeebe Helm Charts"
 
 The following Zeebe Helm Charts are currently available: 
 
-- **Zeebe Cluster Helm (zeebe-cluster-helm)** : Deploys a Zeebe Cluster with 3 brokers using the `camunda/zeebe` docker image. This Chart depends on ElasticSearch Helm Chart and optionally on Kibana Helm Chart. This chart is hosted in the following repository, where you can find more information about its configuration: [http://github.com/zeebe-io/zeebe-cluster-helm/](http://github.com/zeebe-io/zeebe-cluster-helm/)
-- **Zeebe Operate Helm (zeebe-operate-helm)**: Deploys Zeebe Operate which connects to an existing ElasticSearch. This chart source code can be located here: [http://github.com/zeebe-io/zeebe-operate-helm/](http://github.com/zeebe-io/zeebe-operate-helm/)
-- **Zeebe Full Helm (zeebe-full-helm)** (Parent): Deploys a Zeebe Cluster + Operate + Ingress Controller. This parent chart can be located here: [http://github.com/zeebe-io/zeebe-full-helm/](http://github.com/zeebe-io/zeebe-full-helm/)
+- **Zeebe Cluster Helm (zeebe-cluster-helm)** : Deploys a Zeebe Cluster with 3 brokers using the `camunda/zeebe` docker image. This Chart depends on ElasticSearch Helm Chart and optionally on Kibana Helm Chart. This chart is hosted in the following repository, where you can find more information about its configuration: [http://github.com/camunda-community-hub/zeebe-cluster-helm/](http://github.com/camunda-community-hub/zeebe-cluster-helm/)
+- **Zeebe Operate Helm (zeebe-operate-helm)**: Deploys Zeebe Operate which connects to an existing ElasticSearch. This chart source code can be located here: [http://github.com/camunda-community-hub/zeebe-operate-helm/](http://github.com/camunda-community-hub/zeebe-operate-helm/)
+- **Zeebe Full Helm (zeebe-full-helm)** (Parent): Deploys a Zeebe Cluster + Operate + Ingress Controller. This parent chart can be located here: [http://github.com/camunda-community-hub/zeebe-full-helm/](http://github.com/camunda-community-hub/zeebe-full-helm/)
 
-- **Zeebe TaskList Helm (zeebe-tasklist-helm)** (Experimental): Deploys a Task List component to deal with User Tasks. This chart source code can be located here: [http://github.com/zeebe-io/zeebe-tasklist-helm/](http://github.com/zeebe-io/zeebe-tasklist-helm/)
+- **Zeebe TaskList Helm (zeebe-tasklist-helm)** (Experimental): Deploys a Task List component to deal with User Tasks. This chart source code can be located here: [http://github.com/camunda-community-hub/zeebe-tasklist-helm/](http://github.com/camunda-community-hub/zeebe-tasklist-helm/)
 
-- **Zeebe ZeeQS Helm (zeebe-zeeqs-helm)** (Experimental) Deploys a ZeeQS component that provides a Graphql interface to consume Zeebe Process data. This component requires the Hazelcast Exporter configured in the Zeebe Brokers. This chart source code can be located here: [http://github.com/zeebe-io/zeebe-zeeqs-helm/](http://github.com/zeebe-io/zeebe-zeeqs-helm/)
+- **Zeebe ZeeQS Helm (zeebe-zeeqs-helm)** (Experimental) Deploys a ZeeQS component that provides a Graphql interface to consume Zeebe Process data. This component requires the Hazelcast Exporter configured in the Zeebe Brokers. This chart source code can be located here: [http://github.com/camunda-community-hub/zeebe-zeeqs-helm/](http://github.com/camunda-community-hub/zeebe-zeeqs-helm/)
 
-- **Zeebe Kubernetes Operator Helm (zeebe-operator)** (Experimental) Deploys the Zeebe Kubernetes Operator. The Zeebe Operator allows you to declarative provision Zeebe Clusters by interacting with the `kubectl` command-line. This chart source code can be located here: [http://github.com/zeebe-io/zeebe-operator/](http://github.com/zeebe-io/zeebe-operator/)
+- **Zeebe Kubernetes Operator Helm (zeebe-operator)** (Experimental) Deploys the Zeebe Kubernetes Operator. The Zeebe Operator allows you to declarative provision Zeebe Clusters by interacting with the `kubectl` command-line. This chart source code can be located here: [http://github.com/camunda-community-hub/zeebe-operator/](http://github.com/camunda-community-hub/zeebe-operator/)
 
 - **Zeebe CloudEvents Router Helm (zeebe-cloud-events-router)** (Experimental) Deploys the Zeebe CloudEvents Router. This component provides [CloudEvents](http://cloudevents.io) Router to emit and consume CloudEvents from your processes running in Zeebe.
 
@@ -27,9 +27,9 @@ When installing the `zeebe-full-helm` chart all the components marked in green a
 
 ### Add Zeebe Helm Repository
 
-The next step is to add the Zeebe official Helm Chart repository to your installation. Once this is done, Helm will be able to fetch and install Charts hosted in [http://helm.zeebe.io](http://helm.zeebe.io).
+The next step is to add the Zeebe official Helm Chart repository to your installation. Once this is done, Helm will be able to fetch and install Charts hosted in [http://helm.camunda.io](http://helm.camunda.io).
 ```
-> helm repo add zeebe https://helm.zeebe.io
+> helm repo add zeebe https://helm.camunda.io
 > helm repo update
 ```
 
@@ -41,11 +41,7 @@ Once this is done, we are ready to install any of the Helm Charts hosted in the 
 In this section we are going to install all the available Zeebe components inside a Kubernetes Cluster. Notice that this Kubernetes cluster can have already running services and Zeebe is going to installed just as another set of services. 
 
 ```
-<<<<<<< HEAD:versioned_docs/version-0.25/product-manuals/zeebe/kubernetes/installing-helm.md
-> helm install --name <RELEASE NAME> zeebe/zeebe-full
-=======
 > helm install <RELEASE NAME> zeebe/zeebe-full-helm
->>>>>>> updating zeebe helm charts section in the docs:docs/product-manuals/zeebe/kubernetes/installing-helm.md
 ```
 
 > Note: change &gt;RELEASE NAME&lt; with a name of your choice

--- a/docs/product-manuals/zeebe/deployment-guide/kubernetes/operator/zeebe-operator.md
+++ b/docs/product-manuals/zeebe/deployment-guide/kubernetes/operator/zeebe-operator.md
@@ -5,7 +5,7 @@ title: "Zeebe Operator (Experimental)"
 
 The Zeebe Kubernetes Operator was born out of the need to manage more than one single Zeebe cluster running inside Kubernetes clusters. Zeebe clusters have their own lifecycle and in real implementations, the need to update, monitor, and manage some of these cluster components while applications are running becomes challenging. The objective of the Zeebe Kubernetes Operator is to simplify and natively integrate Zeebe with Kubernetes, to solve operational burden and facilitate the creation and maintenance of a set of clusters. 
 
-This operator has been built with Kubernetes Helm in mind, meaning that at the end of the day, this operator will be in charge of managing [Helm charts](https://github.com/helm/helm). If you are not familiar with Helm, Helm is a package manager for Kubernetes, which help us to package and distribute Kubernetes manifest. Helm also deals with installing, labeling and dependency management between packages (charts). Because we have Zeebe Helm packages already here: [http://helm.zeebe.io](http://helm.zeebe.io) which are automatically versioned and released, the Zeebe Kubernetes Operator will use these charts to create and manage new clusters and other related components. 
+This operator has been built with Kubernetes Helm in mind, meaning that at the end of the day, this operator will be in charge of managing [Helm charts](https://github.com/helm/helm). If you are not familiar with Helm, Helm is a package manager for Kubernetes, which help us to package and distribute Kubernetes manifest. Helm also deals with installing, labeling and dependency management between packages (charts). Because we have Zeebe Helm packages already here: [http://helm.camunda.io](http://helm.camunda.io) which are automatically versioned and released, the Zeebe Kubernetes Operator will use these charts to create and manage new clusters and other related components. 
 
 
 Because we are in Kubernetes realms we need to provide a declarative way of stating that we want a new Zeebe cluster to be provisioned. For this reason, the ZeebeCluster Custom Resource Definition (CRD) is introduced. This resource contains all the information needed to provision a cluster and it will also reflect the current cluster status. The Zeebe Kubernetes Operator is built to monitor ZeebeCluster resources and interact with the Kubernetes APIs under the hood to make sure that the Zeebe cluster is provisioned, upgraded or deleted correctly.
@@ -19,7 +19,7 @@ The following steps will guide you to install the Operator with Helm3  (which is
 Add the Zeebe Helm repository:
 
 ```
-helm repo add zeebe https://helm.zeebe.io
+helm repo add zeebe https://helm.camunda.io
 helm repo update
 ```
 
@@ -79,7 +79,7 @@ The next video show these commands in action along with the installation of the 
 
 This Kubernetes Operator was built using KubeBuilder V2.1+, Tekton 0.8.0+ and Helm 3.
 
-The Operator Defines currently 1 CRD (Custom Resource Definition): `ZeebeCluster`, but in future versions, new types will be defined for other components such as Zeebe Operate and workers.  The ZeebeCluster resource represent a low-level resource which will instantiate a Zeebe cluster based on predefined parameters. This low-level resource definition can be used to define the cluster topology and HA configurations.
+The Operator defines currently 1 CRD (Custom Resource Definition): `ZeebeCluster`, but in future versions, new types will be defined for other components such as Zeebe Operate and workers.  The ZeebeCluster resource represent a low-level resource which will instantiate a Zeebe cluster based on predefined parameters. This low-level resource definition can be used to define the cluster topology and HA configurations.
 
 The Zeebe Kubernetes Operator was built using the [kubebuilder framework](https://github.com/kubernetes-sigs/kubebuilder) for writing the controller’s logic and scaffolding the CRD type. Internally it does interact with [Tekton Pipelines](https://github.com/tektoncd/pipeline) in order to install and manage Zeebe Helm charts.  The project itself is being built, released and tested using [Jenkins X](https://jenkins-x.io/). This leads to some changes in how KubeBuilder’s project is structured, as in its current shape the project is not organised in a way that is easy to create a Helm chart out of it.
 

--- a/versioned_docs/version-0.25/product-manuals/zeebe/kubernetes/index.md
+++ b/versioned_docs/version-0.25/product-manuals/zeebe/kubernetes/index.md
@@ -7,7 +7,7 @@ title: "Overview"
 
 This section covers the fundamentals of how to run Zeebe in Kubernetes. There are several alternatives on how to deploy applications to a Kubernetes Cluster, but the following sections are using Helm charts to deploy a set of components into your cluster. 
 
-Helm allows you to choose exactly what chart (set of components) do you want to install and how these components needs to be configured. These Helm Charts are continuously being improved and released to the Official [Zeebe Helm Chart Repository http://helm.zeebe.io](http://helm.zeebe.io)
+Helm allows you to choose exactly what chart (set of components) do you want to install and how these components needs to be configured. These Helm Charts are continuously being improved and released to the Official [Zeebe Helm Chart Repository http://helm.camunda.io](http://helm.camunda.io)
 
 You are free to choose your Kubernetes provider, our Helm charts are not cloud provider specific and we encourage [reporting issues here](http://github.com/zeebe-io/zeebe-full-helm/issues) if you find them. 
 

--- a/versioned_docs/version-0.25/product-manuals/zeebe/kubernetes/installing-helm.md
+++ b/versioned_docs/version-0.25/product-manuals/zeebe/kubernetes/installing-helm.md
@@ -31,9 +31,9 @@ This install Helm server side components in your cluster and it will enable the 
 
 ### Add Zeebe Helm Repository
 
-The next step is to add the Zeebe official Helm Chart repository to your installation. Once this is done, Helm will be able to fetch and install Charts hosted in [http://helm.zeebe.io](http://helm.zeebe.io).
+The next step is to add the Zeebe official Helm Chart repository to your installation. Once this is done, Helm will be able to fetch and install Charts hosted in [http://helm.camunda.io](http://helm.camunda.io).
 ```
-> helm repo add zeebe https://helm.zeebe.io
+> helm repo add zeebe https://helm.camunda.io
 > helm repo update
 ```
 

--- a/versioned_docs/version-0.25/product-manuals/zeebe/kubernetes/zeebe-operator.md
+++ b/versioned_docs/version-0.25/product-manuals/zeebe/kubernetes/zeebe-operator.md
@@ -5,7 +5,7 @@ title: "Zeebe Operator (Experimental)"
 
 The Zeebe Kubernetes Operator was born out of the need to manage more than one single Zeebe Cluster running inside Kubernetes Clusters. Zeebe Clusters have their own lifecycle and in real implementations, the need to update, monitor and manage some of these cluster components while applications are running becomes challenging. The objective of the Zeebe k8s Operator is to simplify and natively integrate Zeebe with k8s, to solve operational burden and facilitate the creation and maintenance of a set of clusters. 
 
-This operator has been built with Kubernetes Helm in mind, meaning that at the end of the day, this operator will be in charge of managing [Helm Charts](https://github.com/helm/helm). If you are not familiar with Helm, Helm is a package manager for Kubernetes, which help us to package and distribute Kubernetes manifest. Helm also deals with installing, labeling and dependency management between packages (charts). Because we have Zeebe Helm packages already here: [http://helm.zeebe.io](http://helm.zeebe.io) which are automatically versioned and released, the Zeebe Kubernetes Operator will use these charts to create and manage new clusters and other related components. 
+This operator has been built with Kubernetes Helm in mind, meaning that at the end of the day, this operator will be in charge of managing [Helm Charts](https://github.com/helm/helm). If you are not familiar with Helm, Helm is a package manager for Kubernetes, which help us to package and distribute Kubernetes manifest. Helm also deals with installing, labeling and dependency management between packages (charts). Because we have Zeebe Helm packages already here: [http://helm.camunda.io](http://helm.camunda.io) which are automatically versioned and released, the Zeebe Kubernetes Operator will use these charts to create and manage new clusters and other related components. 
 
 
 Because we are in Kubernetes realms we need to provide a declarative way of stating that we want a new Zeebe Cluster to be provisioned. For this reason, the ZeebeCluster Custom Resource Definition (CRD) is introduced. This resource contains all the information needed to provision a cluster and it will also reflect the current cluster status. The Zeebe Kubernetes Operator is built to monitor ZeebeCluster resources and interact with the Kubernetes APIs under the hood to make sure that the Zeebe Cluster is provisioned, upgraded or deleted correctly.
@@ -19,7 +19,7 @@ The following steps will guide you to install the Operator with Helm3  (which is
 This will also work if you have correctly installed Helm2 in your cluster with tiller.
 Add the Zeebe Helm Repository:
 
-> helm repo add zeebe https://helm.zeebe.io
+> helm repo add zeebe https://helm.camunda.io
 > helm repo update
 
 Now you are ready to install the Zeebe Kubernetes Operator:


### PR DESCRIPTION
This PR updates all the URL making references to helm.zeebe.io to helm.camunda.io.