### PR TITLE
Remove modeler and workflow lifecycle from bpmn references

### DIFF
--- a/docs/reference/bpmn-processes/call-activities/call-activities.md
+++ b/docs/reference/bpmn-processes/call-activities/call-activities.md
@@ -41,9 +41,8 @@ It is recommended to disable the attribute `propagateAllChildVariables` or defin
 
 ## Additional resources
 
-<details>
-  <summary>XML representation</summary>
-  <p>A call activity with static process id:
+### XML Representation
+A call activity with static process id:
 
 ```xml
 <bpmn:callActivity id="task-A" name="A">
@@ -53,76 +52,7 @@ It is recommended to disable the attribute `propagateAllChildVariables` or defin
 </bpmn:callActivity>
 ```
 
-  </p>
-</details>
-
-<details>
-  <summary>Using the BPMN modeler</summary>
-  <p>Adding a call activity with static process id:
-
-![call-activity](assets/bpmn-modeler-call-activity.gif)
-
-  </p>
-</details>
-
-<details>
-  <summary>Process lifecycle</summary>
-  <p>Process instance records of a call activity:
-
-<table>
-    <tr>
-        <th>Intent</th>
-        <th>Element Id</th>
-        <th>Element Type</th>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATING</td>
-        <td>task-a</td>
-        <td>CALL_ACTIVITY</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATED</td>
-        <td>task-a</td>
-        <td>CALL_ACTIVITY</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATING</td>
-        <td>child-process-id</td>
-        <td>PROCESS</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATED</td>
-        <td>child-process-id</td>
-        <td>PROCESS</td>
-    </tr>
-    <tr>
-        <td>...</td>
-        <td>...</td>
-        <td>...</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETED</td>
-        <td>child-process-id</td>
-        <td>PROCESS</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETING</td>
-        <td>task-a</td>
-        <td>CALL_ACTIVITY</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETED</td>
-        <td>task-a</td>
-        <td>CALL_ACTIVITY</td>
-    </tr>
-</table>
-
-The process instance records of the created process instance have a reference to its parent process instance (`parentProcessInstanceKey`) and the element instance of the call activity (`parentElementInstanceKey`).
-
-  </p>
-</details>
-
-References:
+### References
 
 - [Expressions](/product-manuals/concepts/expressions.md)
 - [Variable scopes](/product-manuals/concepts/variables.md#variable-scopes)

--- a/docs/reference/bpmn-processes/embedded-subprocesses/embedded-subprocesses.md
+++ b/docs/reference/bpmn-processes/embedded-subprocesses/embedded-subprocesses.md
@@ -21,9 +21,8 @@ By default, the local variables of the subprocess are not propagated (i.e. they 
 
 ## Additional resources
 
-<details>
-  <summary>XML representation</summary>
-  <p>An embedded subprocess with a start event:
+### XML Representation
+An embedded subprocess with a start event:
 
 ```xml
 <bpmn:subProcess id="process-order" name="Process Order">
@@ -32,68 +31,6 @@ By default, the local variables of the subprocess are not propagated (i.e. they 
 </bpmn:subProcess>
 ```
 
-  </p>
-</details>
-
-<details>
-  <summary>Using the BPMN modeler</summary>
-  <p>Adding an embedded subprocess:
-
-![event-based-gateway](assets/embedded-subprocess.gif)
-
-  </p>
-</details>
-
-<details>
-  <summary>Process lifecycle</summary>
-  <p>Process instance records of an embedded subprocess:
-
-<table>
-    <tr>
-        <th>Intent</th>
-        <th>Element Id</th>
-        <th>Element Type</th>
-    </tr>    
-    <tr>
-        <td>ELEMENT_ACTIVATING</td>
-        <td>process-order</td>
-        <td>SUB_PROCESS</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATED</td>
-        <td>process-order</td>
-        <td>SUB_PROCESS</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATING</td>
-        <td>order-placed</td>
-        <td>START_EVENT</td>
-    </tr>
-    <tr>
-        <td>...</td>
-        <td>...</td>
-        <td>...</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETED</td>
-        <td>items-fetched</td>
-        <td>END_EVENT</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETING</td>
-        <td>process-order</td>
-        <td>SUB_PROCESS</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETED</td>
-        <td>process-order</td>
-        <td>SUB_PROCESS</td>
-    </tr>
-</table>
-
-  </p>
-</details>
-
-References:
+### References
 
 - [Variable mappings](/product-manuals/concepts/variables.md#inputoutput-variable-mappings)

--- a/docs/reference/bpmn-processes/error-events/error-events.md
+++ b/docs/reference/bpmn-processes/error-events/error-events.md
@@ -49,9 +49,8 @@ A business error is expected and is handled in the process. The process may take
 
 ## Additional resources
 
- <details>
-   <summary>XML representation</summary>
-   <p>A boundary error event:
+ ### XML Representation
+A boundary error event:
 
 ```xml
 <bpmn:error id="invalid-credit-card-error" errorCode="Invalid Credit Card" />
@@ -62,68 +61,6 @@ A business error is expected and is handled in the process. The process may take
 
 ```
 
-   </p>
- </details>
-
- <details>
-   <summary>Using the BPMN modeler</summary>
-   <p>Adding an error boundary event:
-
-![bpmn-modeler](assets/bpmn-modeler-error-events.gif)
-
-   </p>
- </details>
-
- <details>
-   <summary>Process lifecycle</summary>
-   <p>Process instance records of an error boundary event:
-
- <table>
-     <tr>
-         <th>Intent</th>
-         <th>Element Id</th>
-         <th>Element Type</th>
-     </tr>
-     <tr>
-         <td>EVENT_OCCURRED</td>
-         <td>collect-money</td>
-         <td>SERVICE_TASK</td>
-     </tr>
-     <tr>
-       <td>ELEMENT_TERMINATING</td>
-       <td>collect-money</td>
-       <td>SERVICE_TASK</td>
-     </tr>
-     <tr>
-        <td>ELEMENT_TERMINATED</td>
-        <td>collect-money</td>
-        <td>SERVICE_TASK</td>
-      </tr>
-      <tr>
-         <td>ELEMENT_ACTIVATING</td>
-         <td>invalid-credit-card</td>
-         <td>BOUNDARY_EVENT</td>
-     </tr>
-     <tr>
-         <td>ELEMENT_ACTIVATED</td>
-         <td>invalid-credit-card</td>
-         <td>BOUNDARY_EVENT</td>
-     </tr>
-     <tr>
-         <td>ELEMENT_COMPLETING</td>
-         <td>invalid-credit-card</td>
-         <td>BOUNDARY_EVENT</td>
-     </tr>
-     <tr>
-         <td>ELEMENT_COMPLETED</td>
-         <td>invalid-credit-card</td>
-         <td>BOUNDARY_EVENT</td>
-     </tr>
- </table>
-
-   </p>
- </details>
-
-References:
+### References
 
 - [Incidents](/product-manuals/concepts/incidents.md)

--- a/docs/reference/bpmn-processes/event-based-gateways/event-based-gateways.md
+++ b/docs/reference/bpmn-processes/event-based-gateways/event-based-gateways.md
@@ -13,9 +13,8 @@ When an event-based gateway is entered then the process instance waits at the ga
 
 ## Additional resources
 
-<details>
-  <summary>XML representation</summary>
-  <p>An event-based gateway with two outgoing sequence flows:
+### XML Representation
+An event-based gateway with two outgoing sequence flows:
 
 ```xml
 <bpmn:eventBasedGateway id="gateway" />
@@ -36,67 +35,6 @@ When an event-based gateway is entered then the process instance waits at the ga
 </bpmn:intermediateCatchEvent>
 ```
 
-  </p>
-</details>
-
-<details>
-  <summary>Using the BPMN modeler</summary>
-  <p>Adding an event-based gateway with two outgoing sequence flows:
-
-![event-based-gateway](assets/event-based-gateway.gif) 
-  </p>
-</details>
-
-<details>
-  <summary>Process lifecycle</summary>
-  <p>Process instance records of an event-based gateway: 
-
-<table>
-    <tr>
-        <th>Intent</th>
-        <th>Element Id</th>
-        <th>Element Type</th>
-    </tr>    
-    <tr>
-        <td>ELEMENT_ACTIVATING</td>
-        <td>gateway</td>
-        <td>EVENT_BASED_GATEWAY</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATED</td>
-        <td>gateway</td>
-        <td>EVENT_BASED_GATEWAY</td>
-    </tr>
-    <tr>
-        <td>...</td>
-        <td>...</td>
-        <td>...</td>
-    </tr>
-    <tr>
-        <td>EVENT_OCCURRED</td>
-        <td>gateway</td>
-        <td>EVENT_BASED_GATEWAY</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETING</td>
-        <td>gateway</td>
-        <td>EVENT_BASED_GATEWAY</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETED</td>
-        <td>gateway</td>
-        <td>EVENT_BASED_GATEWAY</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATING</td>
-        <td>payment-details-updated</td>
-        <td>INTERMEDIATE_CATCH_EVENT</td>
-    </tr>
-</table>
-
-  </p>
-</details>
-
-References:
+### References
 * [Timer events](../timer-events/timer-events.md)
 * [Message events](../message-events/message-events.md)

--- a/docs/reference/bpmn-processes/event-subprocesses/event-subprocesses.md
+++ b/docs/reference/bpmn-processes/event-subprocesses/event-subprocesses.md
@@ -31,9 +31,8 @@ By default, the local variables of the event subprocess are not propagated (i.e.
 
 ## Additional resources
 
-<details>
-  <summary>XML representation</summary>
-  <p>An event subprocess with an interrupting timer start event:
+### XML Representation
+An event subprocess with an interrupting timer start event:
 
 ```xml
 <bpmn:subProcess id="compensate-subprocess" triggeredByEvent="true">
@@ -45,99 +44,7 @@ By default, the local variables of the event subprocess are not propagated (i.e.
 </bpmn:subProcess>
 ```
 
-  </p>
-</details>
-
-<details>
-	<summary>Using the BPMN modeler</summary>
-  <p>Adding an event subprocess with an interrupting timer start event:
-
-![event-subprocess](assets/zeebe-modeler-event-subprocess.gif)
-
-  </p>
-</details>
-
-<details>
-  <summary>Process lifecycle</summary>
-  <p>Process instance records of an event subprocess with an interrupting timer start event:
-
-<table>
-    <tr>
-        <th>Intent</th>
-        <th>Element Id</th>
-        <th>Element Type</th>
-    </tr>
-		<tr>
-				<td>EVENT_OCCURRED</td>
-				<td>five-minutes</td>
-				<td>START_EVENT</td>
-		</tr>
-		<tr>
-				<td>ELEMENT_TERMINATING</td>
-				<td>fetch-item</td>
-				<td>SERVICE_TASK</td>
-		</tr>
-		<tr>
-				<td>...</td>
-				<td>...</td>
-				<td>...</td>
-		</tr>
-		<tr>
-				<td>ELEMENT_TERMINATED</td>
-				<td>fetch-item</td>
-				<td>SERVICE_TASK</td>
-		</tr>
-    <tr>
-        <td>ELEMENT_ACTIVATING</td>
-        <td>compensate-subprocess</td>
-        <td>SUB_PROCESS</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATED</td>
-        <td>compensate-subprocess</td>
-        <td>SUB_PROCESS</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATING</td>
-        <td>five-minutes</td>
-        <td>START_EVENT</td>
-    </tr>
-    <tr>
-        <td>...</td>
-        <td>...</td>
-        <td>...</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETED</td>
-        <td>order-cancelled</td>
-        <td>END_EVENT</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETING</td>
-        <td>compensate-subprocess</td>
-        <td>SUB_PROCESS</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETED</td>
-        <td>compensate-subprocess</td>
-        <td>SUB_PROCESS</td>
-    </tr>
-		<tr>
-				<td>ELEMENT_COMPLETING</td>
-				<td>order-process</td>
-				<td>PROCESS</td>
-		</tr>
-		<tr>
-				<td>ELEMENT_COMPLETED</td>
-				<td>order-process</td>
-				<td>PROCESS</td>
-		</tr>
-</table>
-
-  </p>
-</details>
-
-References:
+### References
 
 - [Embedded subprocess](../embedded-subprocesses/embedded-subprocesses.md)
 - [Variable scopes](/product-manuals/concepts/variables.md#variable-scopes)

--- a/docs/reference/bpmn-processes/exclusive-gateways/exclusive-gateways.md
+++ b/docs/reference/bpmn-processes/exclusive-gateways/exclusive-gateways.md
@@ -35,9 +35,8 @@ For example:
 
 ## Additional resources
 
-<details>
-  <summary>XML representation</summary>
-  <p>An exclusive gateway with two outgoing sequence flows:
+### XML Representation
+An exclusive gateway with two outgoing sequence flows:
 
 ```xml
 <bpmn:exclusiveGateway id="exclusiveGateway" default="else" />
@@ -53,59 +52,7 @@ For example:
   sourceRef="exclusiveGateway" targetRef="shipParcel" />
 ```
 
-  </p>
-</details>
-
-<details>
-  <summary>Using the BPMN modeler</summary>
-  <p>Adding an exclusive gateway with two outgoing sequence flows:
-
-![exclusive-gateway](assets/exclusive-gateway.gif)
-
-  </p>
-</details>
-
-<details>
-  <summary>Process lifecycle</summary>
-  <p>Process instance records of an exclusive gateway:
-
-<table>
-    <tr>
-        <th>Intent</th>
-        <th>Element Id</th>
-        <th>Element Type</th>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATING</td>
-        <td>shipping-gateway</td>
-        <td>EXCLUSIVE_GATEWAY</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATED</td>
-        <td>shipping-gateway</td>
-        <td>EXCLUSIVE_GATEWAY</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETING</td>
-        <td>shipping-gateway</td>
-        <td>EXCLUSIVE_GATEWAY</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETED</td>
-        <td>shipping-gateway</td>
-        <td>EXCLUSIVE_GATEWAY</td>
-    </tr>
-    <tr>
-        <td>SEQUENCE_FLOW_TAKEN</td>
-        <td>priceGreaterThan100</td>
-        <td>SEQUENCE_FLOW</td>
-    </tr>
-</table>
-
-  </p>
-</details>
-
-References:
+### References
 
 - [Expressions](/product-manuals/concepts/expressions.md)
 - [Incidents](/product-manuals/concepts/incidents.md)

--- a/docs/reference/bpmn-processes/message-events/message-events.md
+++ b/docs/reference/bpmn-processes/message-events/message-events.md
@@ -51,9 +51,8 @@ By default, all message variables are merged into the process instance. This beh
 
 ## Additional resources
 
-<details>
-  <summary>XML representation</summary>
-  <p>A message start event with message definition:
+### XML Representation
+A message start event with message definition:
 
 ```xml
 <bpmn:message id="Message_0z0aft4" name="order-placed" />
@@ -86,99 +85,7 @@ A boundary message event:
 </bpmn:boundaryEvent>
 ```
 
-  </p>
-</details>
-
-<details>
-  <summary>Using the BPMN modeler</summary>
-  <p>Adding an intermediate message catch event:
-
-![message-event](assets/message-event.gif)
-
-  </p>
-</details>
-
-<details>
-  <summary>Process lifecycle</summary>
-  <p>Process instance records of a message start event:
-
-<table>
-    <tr>
-        <th>Intent</th>
-        <th>Element Id</th>
-        <th>Element Type</th>
-    </tr>
-    <tr>
-        <td>EVENT_OCCURRED</td>
-        <td>order-placed</td>
-        <td>START_EVENT</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATING</td>
-        <td>order-placed</td>
-        <td>START_EVENT</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATED</td>
-        <td>order-placed</td>
-        <td>START_EVENT</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETING</td>
-        <td>order-placed</td>
-        <td>START_EVENT</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETED</td>
-        <td>order-placed</td>
-        <td>START_EVENT</td>
-    </tr>
-</table>
-
-Process instance records of an intermediate message catch event:
-
-<table>
-    <tr>
-        <th>Intent</th>
-        <th>Element Id</th>
-        <th>Element Type</th>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATING</td>
-        <td>order-delivered</td>
-        <td>INTERMEDIATE_CATCH_EVENT</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATED</td>
-        <td>order-delivered</td>
-        <td>INTERMEDIATE_CATCH_EVENT</td>
-    </tr>
-    <tr>
-        <td>...</td>
-        <td>...</td>
-        <td>...</td>
-    </tr>
-    <tr>
-        <td>EVENT_OCCURRED</td>
-        <td>money-collected</td>
-        <td>INTERMEDIATE_CATCH_EVENT</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETING</td>
-        <td>money-collected</td>
-        <td>INTERMEDIATE_CATCH_EVENT</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETED</td>
-        <td>money-collected</td>
-        <td>INTERMEDIATE_CATCH_EVENT</td>
-    </tr>
-</table>
-
-  </p>
-</details>
-
-References:
+### References
 
 - [Message correlation](/product-manuals/concepts/messages.md)
 - [Expressions](/product-manuals/concepts/expressions.md)

--- a/docs/reference/bpmn-processes/multi-instance/multi-instance.md
+++ b/docs/reference/bpmn-processes/multi-instance/multi-instance.md
@@ -94,9 +94,8 @@ target: output
 
 ## Additional resources
 
-<details>
-  <summary>XML representation</summary>
-  <p>A sequential multi-instance service task:
+### XML Representation
+A sequential multi-instance service task:
 
 ```xml
 <bpmn:serviceTask id="task-A" name="A">
@@ -110,94 +109,7 @@ target: output
 </bpmn:serviceTask>
 ```
 
-  </p>
-</details>
-
-<details>
-  <summary>Using the BPMN modeler</summary>
-  <p>Adding the parallel multi-instance marker to a service task:
-
-![multi-instance](assets/bpmn-modeler-multi-instance.gif)
-
-  </p>
-</details>
-
-<details>
-  <summary>Process lifecycle</summary>
-  <p>Process instance records of a parallel multi-instance service task:
-
-<table>
-    <tr>
-        <th>Intent</th>
-        <th>Element Id</th>
-        <th>Element Type</th>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATING</td>
-        <td>task-a</td>
-        <td>MULTI_INSTANCE_BODY</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATED</td>
-        <td>task-a</td>
-        <td>MULTI_INSTANCE_BODY</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATING</td>
-        <td>task-a</td>
-        <td>SERVICE_TASK</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATING</td>
-        <td>task-a</td>
-        <td>SERVICE_TASK</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATED</td>
-        <td>task-a</td>
-        <td>SERVICE_TASK</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATED</td>
-        <td>task-a</td>
-        <td>SERVICE_TASK</td>
-    </tr>
-    <tr>
-        <td>...</td>
-        <td>...</td>
-        <td>...</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETED</td>
-        <td>task-a</td>
-        <td>SERVICE_TASK</td>
-    </tr>
-    <tr>
-        <td>...</td>
-        <td>...</td>
-        <td>...</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETED</td>
-        <td>task-a</td>
-        <td>SERVICE_TASK</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETING</td>
-        <td>task-a</td>
-        <td>MULTI_INSTANCE_BODY</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETED</td>
-        <td>task-a</td>
-        <td>MULTI_INSTANCE_BODY</td>
-    </tr>
-</table>
-
-  </p>
-</details>
-
-References:
+### References
 
 - [Variable scopes](/product-manuals/concepts/variables.md#variable-scopes)
 - [Expressions](/product-manuals/concepts/expressions.md)

--- a/docs/reference/bpmn-processes/none-events/none-events.md
+++ b/docs/reference/bpmn-processes/none-events/none-events.md
@@ -20,9 +20,8 @@ If an activity has no outgoing sequence flow then it behaves the same as it woul
 
 ## Additional resources
 
-<details>
-  <summary>XML representation</summary>
-  <p>A none start event:
+### XML Representation
+A none start event:
 
 ```xml
 <bpmn:startEvent id="order-placed" name="Order Placed" />
@@ -32,83 +31,3 @@ A none end event:
 ```xml
 <bpmn:endEvent id="order-delivered" name="Order Delivered" />
 ```
-
-  </p>
-</details>
-
-<details>
-  <summary>Using the BPMN modeler</summary>
-  <p>Adding a none start event:
-
-![start-event](assets/start-event.gif) 
-
-Adding a none end event:
-
-![end-event](assets/end-event.gif) 
-  </p>
-</details>
-
-<details>
-  <summary>Process lifecycle</summary>
-  <p>Process instance records of a none start event: 
-
-<table>
-    <tr>
-        <th>Intent</th>
-        <th>Element Id</th>
-        <th>Element Type</th>
-    </tr>    
-    <tr>
-        <td>ELEMENT_ACTIVATING</td>
-        <td>order-placed</td>
-        <td>START_EVENT</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATED</td>
-        <td>order-placed</td>
-        <td>START_EVENT</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETING</td>
-        <td>order-placed</td>
-        <td>START_EVENT</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETED</td>
-        <td>order-placed</td>
-        <td>START_EVENT</td>
-    </tr>
-</table>
-
-Process instance records of a none end event: 
-
-<table>
-    <tr>
-        <th>Intent</th>
-        <th>Element Id</th>
-        <th>Element Type</th>
-    </tr>    
-    <tr>
-        <td>ELEMENT_ACTIVATING</td>
-        <td>order-delivered</td>
-        <td>END_EVENT</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATED</td>
-        <td>order-delivered</td>
-        <td>END_EVENT</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETING</td>
-        <td>order-delivered</td>
-        <td>END_EVENT</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETED</td>
-        <td>order-delivered</td>
-        <td>END_EVENT</td>
-    </tr>
-</table>
-
-  </p>
-</details>

--- a/docs/reference/bpmn-processes/parallel-gateways/parallel-gateways.md
+++ b/docs/reference/bpmn-processes/parallel-gateways/parallel-gateways.md
@@ -15,9 +15,8 @@ The concurrent paths can be **joined** using a parallel gateway with multiple in
 
 ## Additional Resources
 
-<details>
-  <summary>XML representation</summary>
-  <p>A parallel gateway with two outgoing sequence flows:
+### XML Representation
+A parallel gateway with two outgoing sequence flows:
 
 ```xml
 <bpmn:parallelGateway id="split" />
@@ -28,100 +27,3 @@ The concurrent paths can be **joined** using a parallel gateway with multiple in
 <bpmn:sequenceFlow id="to-process-payment" sourceRef="split" 
   targetRef="processPayment" />
 ```
-
-  </p>
-</details>
-
-<details>
-  <summary>Using the BPMN modeler</summary>
-  <p>Adding a parallel gateway with two outgoing sequence flows:
-
-![parallel-gateway](assets/parallel-gateway.gif) 
-  </p>
-</details>
-
-<details>
-  <summary>Process lifecycle</summary>
-  <p>Process instance records of a parallel gateway: 
-
-<table>
-    <tr>
-        <th>Intent</th>
-        <th>Element Id</th>
-        <th>Element Type</th>
-    </tr>    
-    <tr>
-        <td>ELEMENT_ACTIVATING</td>
-        <td>split</td>
-        <td>PARALLEL_GATEWAY</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATED</td>
-        <td>split</td>
-        <td>PARALLEL_GATEWAY</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETING</td>
-        <td>split</td>
-        <td>PARALLEL_GATEWAY</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETED</td>
-        <td>split</td>
-        <td>PARALLEL_GATEWAY</td>
-    </tr>
-    <tr>
-        <td>SEQUENCE_FLOW_TAKEN</td>
-        <td>to-ship-parcel</td>
-        <td>SEQUENCE_FLOW</td>
-    </tr>
-    <tr>
-        <td>SEQUENCE_FLOW_TAKEN</td>
-        <td>to-process-payment</td>
-        <td>SEQUENCE_FLOW</td>
-    </tr>
-    <tr>
-        <td>...</td>
-        <td>...</td>
-        <td>...</td>
-    </tr>
-    <tr>
-        <td>SEQUENCE_FLOW_TAKEN</td>
-        <td>to-join-1</td>
-        <td>SEQUENCE_FLOW</td>
-    </tr>
-    <tr>
-        <td>...</td>
-        <td>...</td>
-        <td>...</td>
-    </tr>
-    <tr>
-        <td>SEQUENCE_FLOW_TAKEN</td>
-        <td>to-join-2</td>
-        <td>SEQUENCE_FLOW</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATING</td>
-        <td>join</td>
-        <td>PARALLEL_GATEWAY</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATED</td>
-        <td>join</td>
-        <td>PARALLEL_GATEWAY</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETING</td>
-        <td>join</td>
-        <td>PARALLEL_GATEWAY</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETED</td>
-        <td>join</td>
-        <td>PARALLEL_GATEWAY</td>
-    </tr>    
-</table>
-
-  </p>
-</details>
-

--- a/docs/reference/bpmn-processes/receive-tasks/receive-tasks.md
+++ b/docs/reference/bpmn-processes/receive-tasks/receive-tasks.md
@@ -29,9 +29,8 @@ By default, all message variables are merged into the process instance. This beh
 
 ## Additional resources
 
-<details>
-  <summary>XML representation</summary>
-  <p>A receive task with message definition:
+### XML Representation
+A receive task with message definition:
 
 ```xml
 <bpmn:message id="Message_1iz5qtq" name="Money collected">
@@ -45,64 +44,7 @@ By default, all message variables are merged into the process instance. This beh
 </bpmn:receiveTask>
 ```
 
-  </p>
-</details>
-
-<details>
-  <summary>Using the BPMN modeler</summary>
-  <p>Adding a receive task with message:
-
-![receive-task](assets/receive-task.gif)
-
-  </p>
-</details>
-
-<details>
-  <summary>Process Lifecycle</summary>
-  <p>Process instance records of a receive task:
-
-<table>
-    <tr>
-        <th>Intent</th>
-        <th>Element Id</th>
-        <th>Element Type</th>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATING</td>
-        <td>money-collected</td>
-        <td>RECEIVE_TASK</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATED</td>
-        <td>money-collected</td>
-        <td>RECEIVE_TASK</td>
-    </tr>
-    <tr>
-        <td>...</td>
-        <td>...</td>
-        <td>...</td>
-    </tr>
-    <tr>
-        <td>EVENT_OCCURRED</td>
-        <td>money-collected</td>
-        <td>RECEIVE_TASK</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETING</td>
-        <td>money-collected</td>
-        <td>RECEIVE_TASK</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETED</td>
-        <td>money-collected</td>
-        <td>RECEIVE_TASK</td>
-    </tr>
-</table>
-
-  </p>
-</details>
-
-References:
+### References
 
 - [Message correlation](/product-manuals/concepts/messages.md)
 - [Expressions](/product-manuals/concepts/expressions.md)

--- a/docs/reference/bpmn-processes/service-tasks/service-tasks.md
+++ b/docs/reference/bpmn-processes/service-tasks/service-tasks.md
@@ -31,9 +31,8 @@ Input mappings can be used to transform the variables into a format that is acce
 
 ## Additional resources
 
-<details>
-  <summary>XML representation</summary>
-  <p>A service task with a custom header:
+### XML Representation
+A service task with a custom header:
 
 ```xml
 <bpmn:serviceTask id="collect-money" name="Collect Money">
@@ -46,65 +45,7 @@ Input mappings can be used to transform the variables into a format that is acce
 </bpmn:serviceTask>
 ```
 
-  </p>
-</details>
-
-<details>
-  <summary>Using the BPMN modeler</summary>
-  <p>Adding a service task:
-
-![service-task](assets/service-task.gif)
-
-Adding custom headers:
-![task-headers](assets/task-headers.gif)
-
-Adding variable mappings:
-![variable-mappings](assets/variable-mappings.gif)
-
-  </p>
-</details>
-
-<details>
-  <summary>Process Lifecycle</summary>
-  <p>Process instance records of a service task:
-
-<table>
-    <tr>
-        <th>Intent</th>
-        <th>Element Id</th>
-        <th>Element Type</th>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATING</td>
-        <td>collect-money</td>
-        <td>SERVICE_TASK</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATED</td>
-        <td>collect-money</td>
-        <td>SERVICE_TASK</td>
-    </tr>
-    <tr>
-        <td>...</td>
-        <td>...</td>
-        <td>...</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETING</td>
-        <td>collect-money</td>
-        <td>SERVICE_TASK</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETED</td>
-        <td>collect-money</td>
-        <td>SERVICE_TASK</td>
-    </tr>
-</table>
-
-  </p>
-</details>
-
-References:
+### References
 
 - [Job handling](/product-manuals/concepts/job-workers.md)
 - [Expressions](/product-manuals/concepts/expressions.md)

--- a/docs/reference/bpmn-processes/timer-events/timer-events.md
+++ b/docs/reference/bpmn-processes/timer-events/timer-events.md
@@ -65,9 +65,8 @@ A cycle defined as ISO 8601 repeating intervals format. It contains the duration
 
 ## Additional resources
 
-<details>
-  <summary>XML representation</summary>
-  <p>A timer start event with time date:
+### XML Representation
+A timer start event with time date:
 
 ```xml
  <bpmn:startEvent id="release-date">
@@ -97,99 +96,7 @@ A non-interrupting boundary timer event with time cycle:
 </bpmn:boundaryEvent>
 ```
 
-  </p>
-</details>
-
-<details>
-  <summary>Using the BPMN modeler</summary>
-  <p>Adding an interrupting timer boundary event:
-
-![message-event](assets/interrupting-timer-event.gif)
-
-  </p>
-</details>
-
-<details>
-  <summary>Process lifecycle</summary>
-  <p>Process instance records of a timer start event:
-
-<table>
-    <tr>
-        <th>Intent</th>
-        <th>Element Id</th>
-        <th>Element Type</th>
-    </tr>
-    <tr>
-        <td>EVENT_OCCURRED</td>
-        <td>release-date</td>
-        <td>START_EVENT</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATING</td>
-        <td>release-date</td>
-        <td>START_EVENT</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATED</td>
-        <td>release-date</td>
-        <td>START_EVENT</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETING</td>
-        <td>release-date</td>
-        <td>START_EVENT</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETED</td>
-        <td>release-date</td>
-        <td>START_EVENT</td>
-    </tr>
-</table>
-
-Process instance records of an intermediate timer catch event:
-
-<table>
-    <tr>
-        <th>Intent</th>
-        <th>Element Id</th>
-        <th>Element Type</th>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATING</td>
-        <td>coffee-break</td>
-        <td>INTERMEDIATE_CATCH_EVENT</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_ACTIVATED</td>
-        <td>coffee-break</td>
-        <td>INTERMEDIATE_CATCH_EVENT</td>
-    </tr>
-    <tr>
-        <td>...</td>
-        <td>...</td>
-        <td>...</td>
-    </tr>
-    <tr>
-        <td>EVENT_OCCURRED</td>
-        <td>coffee-break</td>
-        <td>INTERMEDIATE_CATCH_EVENT</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETING</td>
-        <td>coffee-break</td>
-        <td>INTERMEDIATE_CATCH_EVENT</td>
-    </tr>
-    <tr>
-        <td>ELEMENT_COMPLETED</td>
-        <td>coffee-break</td>
-        <td>INTERMEDIATE_CATCH_EVENT</td>
-    </tr>
-</table>
-
-  </p>
-</details>
-
-References:
+### References
 
 - [Expressions](/product-manuals/concepts/expressions.md)
 - [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)


### PR DESCRIPTION
- modeler gifs have to be updated and should maybe moved to the modeler docs
- workflow life cycle has to be updated
- promote xml representation and references to be subsections to be visible in table of content

closes #235 