### PR TITLE
fix(csharp-client): use correct api doc link

### DIFF
--- a/docs/product-manuals/clients/other-clients/c-sharp.md
+++ b/docs/product-manuals/clients/other-clients/c-sharp.md
@@ -7,4 +7,4 @@ The C# client is a community library maintained by [Christopher Zell](https://gi
 
 * [Source code](https://github.com/zeebe-io/zeebe-client-csharp)
 * [Nuget package](https://www.nuget.org/packages/zb-client/)
-* [API docs](https://zeebe-io.github.io/zeebe-client-csharp/index.html)
+* [API docs](https://camunda-community-hub.github.io/zeebe-client-csharp/)


### PR DESCRIPTION
In the latest docs a wrong link is used for the C# Client API docs