### PR TITLE
Osano and GTAG/GTM Fixes

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -198,7 +198,7 @@ module.exports = {
           customCss: require.resolve("./src/css/custom.css"),
         },
         sitemap: {
-          cacheTime: 600 * 1000, // 600 sec - cache purge period
+          //cacheTime: 600 * 1000, // 600 sec - cache purge period
           changefreq: "weekly",
           priority: 0.5,
           trailingSlash: false,

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -57,24 +57,23 @@ body {
 
 .osano-cm-widget svg {
   display: none;
-}
-.osano-cm-widget svg {
+  }
+  .osano-cm-widget svg {
   display: none;
-}
-.osano-cm-widget:focus,
-.osano-cm-widget:hover {
+  }
+  .osano-cm-widget:focus,
+  .osano-cm-widget:hover {
   opacity: 1;
   transform: none;
-}
-.osano-cm-widget:active {
+  }
+  .osano-cm-widget:active {
   transform: translateY(1px);
-}
-.osano-cm-link {
-  color: #002f66 !important;
-}
-.osano-cm-close {
-  background: transparent !important;
-}
-.osano-cm-view--type_consent .osano-cm-list-item:nth-child(5) {
-  display: none;
-}
+  }
+  .osano-cm-link {
+  color: #002f66 !important;}
+  .osano-cm-close {
+    background: transparent !important;}
+  div.osano-cm-info__info-views.osano-cm-info-views.osano-cm-info-views--position_0 > div > ul > li:last-of-type {
+      display: none;
+  }
+  


### PR DESCRIPTION
* Osano CSS
* anonymized IPs for GA
* build error, had to remove sitemap cacheTime 

^ Build error only occurred on the commit build, not on my local build. This is the first time I've experienced this. Is there an additional command or check we can run locally to check for these deprecation-triggered build errors? Or is my local environment not running latest? 

```
A validation error occured.
The validation system was added recently to Docusaurus as an attempt to avoid user configuration errors.
error building locale=en
We may have made some mistakes.
ValidationError: Option `cacheTime` in sitemap config is deprecated. Please remove it.
If you think your configuration is valid and should keep working, please open a bug report.
```