### PR TITLE
Add new links to community hub repository location

### DIFF
--- a/docs/product-manuals/clients/other-clients/javascript.md
+++ b/docs/product-manuals/clients/other-clients/javascript.md
@@ -15,7 +15,7 @@ The Zeebe Node client is maintained by [Josh Wulf](https://github.com/jwulf). It
 
 The NestJS client is maintained by [Dan Shapir](https://github.com/danshapir). It is a microservice transport that integrates Zeebe with the [NestJS](https://nestjs.com/) framework.
 
-- [Source code](https://github.com/camunda-community-hub/nestjs-zeebe#readme)
+- [Source code](https://github.com/camunda-community-hub/nestjs-zeebe)
 - [NPM package](https://www.npmjs.com/package/@payk/nestjs-zeebe)
 - [Podcast interview with Dan Shapir](https://zeebe.buzzsprout.com/454051/1989112-zeebe-and-nestjs)
 

--- a/docs/product-manuals/clients/other-clients/javascript.md
+++ b/docs/product-manuals/clients/other-clients/javascript.md
@@ -15,7 +15,7 @@ The Zeebe Node client is maintained by [Josh Wulf](https://github.com/jwulf). It
 
 The NestJS client is maintained by [Dan Shapir](https://github.com/danshapir). It is a microservice transport that integrates Zeebe with the [NestJS](https://nestjs.com/) framework.
 
-- [Source code](https://github.com/pay-k/nestjs-zeebe)
+- [Source code](https://github.com/camunda-community-hub/nestjs-zeebe#readme)
 - [NPM package](https://www.npmjs.com/package/@payk/nestjs-zeebe)
 - [Podcast interview with Dan Shapir](https://zeebe.buzzsprout.com/454051/1989112-zeebe-and-nestjs)
 
@@ -23,7 +23,7 @@ The NestJS client is maintained by [Dan Shapir](https://github.com/danshapir). I
 
 The [Node-RED](https://nodered.org/) Zeebe client is maintained by [Patrick Dehn](https://github.com/pedesen).
 
-- [Source code](https://github.com/pedesen/node-red-contrib-zeebe)
+- [Source code](https://github.com/camunda-community-hub/node-red-contrib-zeebe)
 - [NPM package](https://www.npmjs.com/package/node-red-contrib-zeebe)
 
 ## Workit Zeebe Client


### PR DESCRIPTION
Updated links to the Node-RED and NestJS repos to indicate their migration to the Camunda Community Hub