### PR TITLE
The figure and the table don’t seem to match

### DIFF
--- a/docs/product-manuals/zeebe/technical-concepts/process-lifecycles.md
+++ b/docs/product-manuals/zeebe/technical-concepts/process-lifecycles.md
@@ -103,12 +103,12 @@ Given the above process a successful execution will yield the following records 
         <td>sequence flow</td>
     </tr>
     <tr>
-        <td>EVENT_ACTIVATING</td>
+        <td>ELEMENT_ACTIVATING</td>
         <td>order-delivered</td>
         <td>end event</td>
     </tr>
     <tr>
-        <td>EVENT_ACTIVATED</td>
+        <td>ELEMENT_ACTIVATED</td>
         <td>order-delivered</td>
         <td>end event</td>
     </tr>


### PR DESCRIPTION
It seems that there aren't `EVENT_ACTIVATING` and `EVENT_ACTIVATED` in the Event-lifecycle diagram. So I guess it should be **ELEMENT_ACTIVATING** and **ELEMENT_ACTIVATED**. 
![image](https://user-images.githubusercontent.com/55177318/122765905-8e2a4780-d2d3-11eb-8673-482c3d755f03.png)
![image](https://user-images.githubusercontent.com/55177318/122768021-c894e400-d2d5-11eb-9dec-da2e834fa25e.png)

Please correct me if I understand it wrong. Thank you!