### PR TITLE
Enable contextual-search for Algolia

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -137,6 +137,7 @@ module.exports = {
     algolia: {
       apiKey: "f1b2a46296ae374b7f5a5c627341c354",
       indexName: "camunda",
+      contextualSearch: true, // useful for versioned docs (https://docusaurus.io/docs/search#contextual-search)
       searchParameters: {}, // Optional (if provided by Algolia)
     },
     // Disabling Dark Mode


### PR DESCRIPTION
* contextual-search is useful for versioned docs to avoid multiple results from different versions

See here: https://docusaurus.io/docs/search#contextual-search

closes #280 