### PR TITLE
Trailing slash config

### DIFF
--- a/docs/product-manuals/overview.md
+++ b/docs/product-manuals/overview.md
@@ -7,13 +7,13 @@ slug: /product-manuals/
 
 This section contains product manual content for each product in Camunda Cloud, including conceptual content.
 
-- [Concepts](concepts/what-is-camunda-cloud) - Conceptual documentation on a variety of Camunda Cloud topics.
-- [Clients](clients/overview) - Supported clients for working with Camunda Cloud, including information on building your own.
-- [Cloud Console](cloud-console/introduction) - More information on working with the Cloud Console.
-- [Modeler](modeler/overview) - Documentation covering Camunda's modeling tools, including Cloud Modeler and Camunda Modeler.
-- [Zeebe Engine](zeebe/zeebe-overview) - Complete documentation for Zeebe. 
+- [Concepts](concepts/what-is-camunda-cloud.md) - Conceptual documentation on a variety of Camunda Cloud topics.
+- [Clients](clients/overview.md) - Supported clients for working with Camunda Cloud, including information on building your own.
+- [Cloud Console](cloud-console/introduction.md) - More information on working with the Cloud Console.
+- [Modeler](modeler/overview.md) - Documentation covering Camunda's modeling tools, including Cloud Modeler and Camunda Modeler.
+- [Zeebe Engine](zeebe/zeebe-overview.md) - Complete documentation for Zeebe. 
 - [Operate](operate/index.md) - User and deployment guide for Operate.
-- [Tasklist](tasklist/deployment/configuration) - Deployment guide for Tasklist.
+- [Tasklist](tasklist/deployment/configuration.md) - Deployment guide for Tasklist.
 - [IAM](iam/overview.md) - Documentation covering the IAM offering.
 
 While Camunda Cloud is cloud-first, applicable sections, like Zeebe Engine, include on-prem operation steps.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,6 +9,7 @@ module.exports = {
   favicon: "img/favicon.ico",
   organizationName: "camunda-cloud", // Usually your GitHub org/user name.
   projectName: "camunda-cloud-documentation", // Usually your repo name.
+  trailingSlash: false,
   plugins: [
     //    ["@edno/docusaurus2-graphql-doc-generator",
     //      {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -211,7 +211,6 @@ module.exports = {
           //cacheTime: 600 * 1000, // 600 sec - cache purge period
           changefreq: "weekly",
           priority: 0.5,
-          trailingSlash: false,
         },
       },
     ],

--- a/versioned_docs/version-0.25/product-manuals/overview.md
+++ b/versioned_docs/version-0.25/product-manuals/overview.md
@@ -8,10 +8,10 @@ slug: /product-manuals/
 This section contains product manual content for each product in Camunda Cloud, including conceptual content.
 
 - [Clients](clients/nodejs/install-the-nodejs-client.md) - Supported clients for working with Camunda Cloud, including information on building your own.
-- [Cloud Console](cloud-console/overview) - More information on working with the Cloud Console.
-- [Modeler](modeler/install-the-modeler) - Installation steps for the modeler.
-- [Zeebe Engine](zeebe/zeebe-overview) - Complete documentation for Zeebe. 
+- [Cloud Console](cloud-console/overview.md) - More information on working with the Cloud Console.
+- [Modeler](modeler/install-the-modeler.md) - Installation steps for the modeler.
+- [Zeebe Engine](zeebe/zeebe-overview.md) - Complete documentation for Zeebe. 
 - [Operate](operate/userguide/index.md) - User and deployment guide for Operate.
-- [Tasklist](tasklist/deployment/configuration) - Deployment guide for Tasklist.
+- [Tasklist](tasklist/deployment/configuration.md) - Deployment guide for Tasklist.
 
 While Camunda Cloud is cloud-first, applicable sections, like Zeebe Engine, include on-prem operation steps.

--- a/versioned_docs/version-0.26/product-manuals/overview.md
+++ b/versioned_docs/version-0.26/product-manuals/overview.md
@@ -7,12 +7,12 @@ slug: /product-manuals/
 
 This section contains product manual content for each product in Camunda Cloud, including conceptual content.
 
-- [Concepts](concepts/what-is-camunda-cloud) - Conceptual documentation on a variety of Camunda Cloud topics.
-- [Clients](clients/overview) - Supported clients for working with Camunda Cloud, including information on building your own.
-- [Cloud Console](cloud-console/introduction) - More information on working with the Cloud Console.
-- [Modeler](modeler/overview) - Documentation covering Camunda's modeling tools, including Cloud Modeler and Zeebe Modeler.
-- [Zeebe Engine](zeebe/zeebe-overview) - Complete documentation for Zeebe. 
+- [Concepts](concepts/what-is-camunda-cloud.md) - Conceptual documentation on a variety of Camunda Cloud topics.
+- [Clients](clients/overview.md) - Supported clients for working with Camunda Cloud, including information on building your own.
+- [Cloud Console](cloud-console/introduction.md) - More information on working with the Cloud Console.
+- [Modeler](modeler/overview.md) - Documentation covering Camunda's modeling tools, including Cloud Modeler and Zeebe Modeler.
+- [Zeebe Engine](zeebe/zeebe-overview.md) - Complete documentation for Zeebe. 
 - [Operate](operate/index.md) - User and deployment guide for Operate.
-- [Tasklist](tasklist/deployment/configuration) - Deployment guide for Tasklist.
+- [Tasklist](tasklist/deployment/configuration.md) - Deployment guide for Tasklist.
 
 While Camunda Cloud is cloud-first, applicable sections, like Zeebe Engine, include on-prem operation steps.

--- a/versioned_docs/version-1.0/product-manuals/overview.md
+++ b/versioned_docs/version-1.0/product-manuals/overview.md
@@ -7,12 +7,12 @@ slug: /product-manuals/
 
 This section contains product manual content for each product in Camunda Cloud, including conceptual content.
 
-- [Concepts](concepts/what-is-camunda-cloud) - Conceptual documentation on a variety of Camunda Cloud topics.
-- [Clients](clients/overview) - Supported clients for working with Camunda Cloud, including information on building your own.
-- [Cloud Console](cloud-console/introduction) - More information on working with the Cloud Console.
-- [Modeler](modeler/overview) - Documentation covering Camunda's modeling tools, including Cloud Modeler and Camunda Modeler.
-- [Zeebe Engine](zeebe/zeebe-overview) - Complete documentation for Zeebe. 
+- [Concepts](concepts/what-is-camunda-cloud.md) - Conceptual documentation on a variety of Camunda Cloud topics.
+- [Clients](clients/overview.md) - Supported clients for working with Camunda Cloud, including information on building your own.
+- [Cloud Console](cloud-console/introduction.md) - More information on working with the Cloud Console.
+- [Modeler](modeler/overview.md) - Documentation covering Camunda's modeling tools, including Cloud Modeler and Camunda Modeler.
+- [Zeebe Engine](zeebe/zeebe-overview.md) - Complete documentation for Zeebe. 
 - [Operate](operate/index.md) - User and deployment guide for Operate.
-- [Tasklist](tasklist/deployment/configuration) - Deployment guide for Tasklist.
+- [Tasklist](tasklist/deployment/configuration.md) - Deployment guide for Tasklist.
 
 While Camunda Cloud is cloud-first, applicable sections, like Zeebe Engine, include on-prem operation steps.


### PR DESCRIPTION
This PR addresses trailing slash concerns in #304 and #269.

* Add `trailingSlash` config, set to false
* Remove `trailingSlash` from sitemap plugin (deprecation warning)
* Update previous version docs to add .md to fix broken links