### PR TITLE
Switch orange to green on BPMN coverage

### DIFF
--- a/docs/reference/bpmn-processes/bpmn-coverage.md
+++ b/docs/reference/bpmn-processes/bpmn-coverage.md
@@ -9,7 +9,7 @@ export const Highlight = ({children, color}) => (
 </span>
 );
 
-The following BPMN elements in <Highlight color="#df8a13">orange</Highlight> are supported. Click on
+The following BPMN elements in <Highlight color="#11c399">green</Highlight> are supported. Click on
 an element to navigate to the documentation.
 
 ## Participants

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -79,11 +79,11 @@ body {
 
 /* style SVG images of the BPMN coverage page */
 svg.implemented [fill="#333"]{
-  fill:#df8a13
+  fill:#11c399
 }
 
 svg.implemented [stroke="#333"]{
-  stroke:#df8a13
+  stroke:#11c399
 }
 
 svg.implemented:hover [fill="#333"]{

--- a/versioned_docs/version-0.25/product-manuals/zeebe/bpmn-workflows/bpmn-coverage.md
+++ b/versioned_docs/version-0.25/product-manuals/zeebe/bpmn-workflows/bpmn-coverage.md
@@ -9,7 +9,7 @@ export const Highlight = ({children, color}) => (
 </span>
 );
 
-The following BPMN elements in <Highlight color="#df8a13">orange</Highlight> are supported. Click on
+The following BPMN elements in <Highlight color="#11c399">green</Highlight> are supported. Click on
 an element to navigate to the documentation.
 
 ## Participants

--- a/versioned_docs/version-0.26/reference/bpmn-workflows/bpmn-coverage.md
+++ b/versioned_docs/version-0.26/reference/bpmn-workflows/bpmn-coverage.md
@@ -9,7 +9,7 @@ export const Highlight = ({children, color}) => (
 </span>
 );
 
-The following BPMN elements in <Highlight color="#df8a13">orange</Highlight> are supported. Click on
+The following BPMN elements in <Highlight color="#11c399">green</Highlight> are supported. Click on
 an element to navigate to the documentation.
 
 ## Participants

--- a/versioned_docs/version-1.0/reference/bpmn-processes/bpmn-coverage.md
+++ b/versioned_docs/version-1.0/reference/bpmn-processes/bpmn-coverage.md
@@ -9,7 +9,7 @@ export const Highlight = ({children, color}) => (
 </span>
 );
 
-The following BPMN elements in <Highlight color="#df8a13">orange</Highlight> are supported. Click on
+The following BPMN elements in <Highlight color="#11c399">green</Highlight> are supported. Click on
 an element to navigate to the documentation.
 
 ## Participants


### PR DESCRIPTION
The orange highlighting currently used in the BPMN coverage map
feels like a warning color that one would expect to be used for the unsupported elements.
In addition the color is not a Camunda brand color.
The replacement color is from the official Icemunda color scale
and fits nicely to the hover color.
