### PR TITLE
Add experimental config note

### DIFF
--- a/docs/product-manuals/zeebe/deployment-guide/configuration/configuration.md
+++ b/docs/product-manuals/zeebe/deployment-guide/configuration/configuration.md
@@ -180,3 +180,17 @@ Health probes are set to sensible defaults which cover common use cases.
 For specific use cases, it might be necessary to customize health probes:
 
 - [Gateway health probes](gateway-health-probes.md)
+
+## Experimental configuration options
+
+You may have already noticed a special section of Zeebe's configuration templates titled `experimental`.
+This section refers to settings which are potentially not backwards compatible - in other words, any special configuration 
+setting found there may or may not be dropped in any minor version.
+
+These settings are there primarily for incubating features and/or very advanced settings for which the team has not found
+a good general default configuration. Once one is found, or the incubating feature is promoted, the setting(s) will be moved
+into a different section. Only at that point do they fall under the same backwards compatibility guarantees as the rest of
+the project.
+
+Most users should not have to change anything in this section to get a good experience. However, if you have a unique set up, or 
+simply wish to try out new experimental features, it can be worth investigating these (ideally with the guidance of the Zeebe community).

--- a/docs/product-manuals/zeebe/deployment-guide/configuration/configuration.md
+++ b/docs/product-manuals/zeebe/deployment-guide/configuration/configuration.md
@@ -184,7 +184,7 @@ For specific use cases, it might be necessary to customize health probes:
 ## Experimental configuration options
 
 You may have already noticed a special section of Zeebe's configuration templates titled `experimental`.
-This section refers to settings which are potentially not backwards compatible - in other words, any special configuration 
+This section refers to settings which are potentially not backwards compatible - in other words, any configuration 
 setting found there may or may not be dropped in any minor version.
 
 These settings are there primarily for incubating features and/or very advanced settings for which the team has not found

--- a/docs/product-manuals/zeebe/deployment-guide/configuration/configuration.md
+++ b/docs/product-manuals/zeebe/deployment-guide/configuration/configuration.md
@@ -190,7 +190,7 @@ setting found there may or may not be dropped in any minor version.
 These settings are there primarily for incubating features and/or very advanced settings for which the team has not found
 a good general default configuration. Once one is found, or the incubating feature is promoted, the setting(s) may be moved
 into a different section. Only at that point do they fall under the same backwards compatibility guarantees as the rest of
-the project.
+the project. We may choose to drop support for specific experimental configurations in any minor version update.
 
 Most users should not have to change anything in this section to get a good experience. However, if you have a unique set up, or 
 simply wish to try out new experimental features, it can be worth investigating these (ideally with the guidance of the Zeebe community).

--- a/docs/product-manuals/zeebe/deployment-guide/configuration/configuration.md
+++ b/docs/product-manuals/zeebe/deployment-guide/configuration/configuration.md
@@ -188,7 +188,7 @@ This section refers to settings which are potentially not backwards compatible -
 setting found there may or may not be dropped in any minor version.
 
 These settings are there primarily for incubating features and/or very advanced settings for which the team has not found
-a good general default configuration. Once one is found, or the incubating feature is promoted, the setting(s) will be moved
+a good general default configuration. Once one is found, or the incubating feature is promoted, the setting(s) may be moved
 into a different section. Only at that point do they fall under the same backwards compatibility guarantees as the rest of
 the project.
 


### PR DESCRIPTION
Adds a short paragraph explaining the pitfalls of the experimental configuration section, specifically those related to the backwards compatibility guarantees.

closes #38 