### PR TITLE
Editorialreview/servicetasks/addedlinks

### DIFF
--- a/docs/reference/bpmn-processes/service-tasks/service-tasks.md
+++ b/docs/reference/bpmn-processes/service-tasks/service-tasks.md
@@ -9,7 +9,7 @@ A service task represents a work item in the process with a specific type.
 
 When a service task is entered, a corresponding job is created. The process instance stops at this point and waits until the job is complete.
 
-A worker can subscribe to the job type, process the jobs, and complete them using one of the Zeebe clients. When the job is complete, the service task is completed and the process instance continues.
+A [job worker](/product-manuals/concepts/job-workers.md) can subscribe to the job type, process the jobs, and complete them using one of the Zeebe clients. When the job is complete, the service task is completed and the process instance continues.
 
 ## Task definition
 
@@ -27,7 +27,7 @@ A service task can define an arbitrary number of `taskHeaders`. They are static 
 
 By default, all job variables merge into the process instance. This behavior can be customized by defining an output mapping at the service task.
 
-Input mappings can be used to transform the variables into a format accepted by the [job worker](/product-manuals/concepts/job-workers.md).
+Input mappings can be used to transform the variables into a format accepted by the job worker.
 
 ## Additional resources
 

--- a/docs/reference/bpmn-processes/service-tasks/service-tasks.md
+++ b/docs/reference/bpmn-processes/service-tasks/service-tasks.md
@@ -48,7 +48,7 @@ A service task with a custom header:
 
 ## Next steps
 
-Learn more about the concept of job types and how to set up a job worker via our guide [here](/product-manuals/concepts/job-workers.md).
+Learn more about the concept of job types and how to set up a job worker via our [manual on job workers](/product-manuals/concepts/job-workers.md).
 
 ### References
 

--- a/docs/reference/bpmn-processes/service-tasks/service-tasks.md
+++ b/docs/reference/bpmn-processes/service-tasks/service-tasks.md
@@ -7,7 +7,7 @@ A service task represents a work item in the process with a specific type.
 
 ![process](../assets/order-process.png)
 
-When a service task is entered, a corresponding job is created. The process instance stops at this point and waits until the job is complete.
+When a service task is entered, a corresponding job is created. The process instance stops here and waits until the job is complete.
 
 A [job worker](/product-manuals/concepts/job-workers.md) can subscribe to the job type, process the jobs, and complete them using one of the Zeebe clients. When the job is complete, the service task is completed and the process instance continues.
 

--- a/docs/reference/bpmn-processes/service-tasks/service-tasks.md
+++ b/docs/reference/bpmn-processes/service-tasks/service-tasks.md
@@ -27,7 +27,7 @@ A service task can define an arbitrary number of `taskHeaders`. They are static 
 
 By default, all job variables merge into the process instance. This behavior can be customized by defining an output mapping at the service task.
 
-Input mappings can be used to transform the variables into a format accepted by the job worker.
+Input mappings can be used to transform the variables into a format accepted by the [job worker](/product-manuals/concepts/job-workers.md).
 
 ## Additional resources
 
@@ -45,6 +45,10 @@ A service task with a custom header:
   </bpmn:extensionElements>
 </bpmn:serviceTask>
 ```
+
+## Next steps
+
+Learn more about the concept of job types and how to set up a job worker via our guide [here](/product-manuals/concepts/job-workers.md).
 
 ### References
 

--- a/docs/reference/bpmn-processes/service-tasks/service-tasks.md
+++ b/docs/reference/bpmn-processes/service-tasks/service-tasks.md
@@ -17,7 +17,7 @@ A service task must have a `taskDefinition`. This specifies the type of job work
 
 Optionally, a `taskDefinition` can specify the number of times the job is retried when a worker signals failure (default = 3).
 
-Usually, the job type and the job retries are defined as static values (e.g. `order-items`) but they can also be defined as [expressions](/product-manuals/concepts/expressions.md) (e.g. `= "order-" + priorityGroup`). The expressions are evaluated on activating the service task and must result in a `string` for the job type and a `number` for the retries.
+Typically, the job type and the job retries are defined as static values (e.g. `order-items`) but they can also be defined as [expressions](/product-manuals/concepts/expressions.md) (e.g. `= "order-" + priorityGroup`). The expressions are evaluated on activating the service task and must result in a `string` for the job type and a `number` for the retries.
 
 ## Task headers
 


### PR DESCRIPTION
Editorial review of service task documentation. Added next steps section for clarity, and additional linkage to job worker documentation for an easier user experience.