### PR TITLE
Add action to publish to datacenter

### DIFF
--- a/.github/workflows/publish-prod.yaml
+++ b/.github/workflows/publish-prod.yaml
@@ -1,0 +1,28 @@
+name: publish-prod
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Install Dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Publish
+        uses: burnett01/rsync-deployments@5.1
+        with:
+          switches: -avzr --delete
+          path: build/
+          remote_path: ${{ secrets.PUBLISH_PROD_PATH }}
+          remote_host: ${{ secrets.PUBLISH_PROD_HOST }}
+          remote_user: ${{ secrets.PUBLISH_PROD_USER }}
+          remote_key: ${{ secrets.PUBLISH_PROD_KEY }}

--- a/.github/workflows/publish-stage.yaml
+++ b/.github/workflows/publish-stage.yaml
@@ -1,0 +1,34 @@
+name: publish-stage
+
+on:
+  push:
+    branches:
+      - "master"
+    tags-ignore:
+      - "*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - name: Install Dependencies
+        run: npm ci
+      - name: Disable Indexing
+        run: "sed -i 's/noIndex: false/noIndex: true/g' docusaurus.config.js"
+      - name: Update URL
+        run: "sed -i 's!url: \"https://docs.camunda.io\"!url: \"https://stage.docs.camunda.io\"!g' docusaurus.config.js"
+      - name: Build
+        run: npm run build
+      - name: Publish
+        uses: burnett01/rsync-deployments@5.1
+        with:
+          switches: -avzr --delete
+          path: build/
+          remote_path: ${{ secrets.PUBLISH_STAGE_PATH }}
+          remote_host: ${{ secrets.PUBLISH_STAGE_HOST }}
+          remote_user: ${{ secrets.PUBLISH_STAGE_USER }}
+          remote_key: ${{ secrets.PUBLISH_STAGE_KEY }}

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -10,6 +10,8 @@ module.exports = {
   organizationName: "camunda-cloud", // Usually your GitHub org/user name.
   projectName: "camunda-cloud-documentation", // Usually your repo name.
   trailingSlash: false,
+  // do not delete the following 'noIndex' line as it is modified for staging
+  noIndex: false,
   plugins: [
     //    ["@edno/docusaurus2-graphql-doc-generator",
     //      {

--- a/howtos/publish-documentation.md
+++ b/howtos/publish-documentation.md
@@ -4,14 +4,24 @@
 
 Putting the documentation online happens automatically. The source is always `Master`.
 
-## Steps
+## Staging
 
-1. Make sure that all changes are in the `Master`
+Every push to the `master` branch will update the stage environment at https://stage.docs.camunda.io
+
+Technically [this Github Workflow](/.github/workflows/publish-stage.yaml) will be triggered by the Release to build and deploy the docs.
+
+You can observe the progress of the Build under [https://github.com/camunda-cloud/camunda-cloud-documentation/actions](https://github.com/camunda-cloud/camunda-cloud-documentation/actions).
+
+## Release to Production
+
+### Steps
+
+1. Make sure that all changes are in the `master` branch
 2. Switch to the Releases view: [https://github.com/camunda-cloud/camunda-cloud-documentation/releases](https://github.com/camunda-cloud/camunda-cloud-documentation/releases)
 3. Create a new release using the button _Draft a new release_.
 4. Fill out the form: Tag version (semver: 'x.y.z'), Release title, Description
 5. Click on _Publish release_
 
-Technically [this Github Process](./.github/processes/publish.yaml) will be triggered by the Release to build and deploy the docs.
+Technically [this Github Workflow](/.github/workflows/publish-prod.yaml) will be triggered by the Release to build and deploy the docs.
 
 You can observe the progress of the Build under [https://github.com/camunda-cloud/camunda-cloud-documentation/actions](https://github.com/camunda-cloud/camunda-cloud-documentation/actions).


### PR DESCRIPTION
This change adds two new GitHub workflows to publish the docs to the Apache in the datacenter in Frankfurt. The old workflow to publish the GitHub pages still exists and will continue to work. Until we redirected the DNS entry nothing will change.