### PR TITLE
fix: rename the IAM landing page

### DIFF
--- a/docs/components/iam/overview.md
+++ b/docs/components/iam/overview.md
@@ -1,7 +1,0 @@
----
-id: overview
-title: "IAM"
-sidebar_label: "Overview"
----
-
-IAM provides authentication and authorization functionality along with user management.

--- a/docs/components/iam/what-is-iam.md
+++ b/docs/components/iam/what-is-iam.md
@@ -1,0 +1,10 @@
+---
+id: what-is-iam
+title: "What is IAM?"
+sidebar_label: "What is IAM?"
+---
+
+IAM is the component within the Camunda Cloud stack that is responsible for authentication and authorization. It allows you to:
+- Manage users
+- Manage roles
+- Manage permissions

--- a/docs/components/overview.md
+++ b/docs/components/overview.md
@@ -14,6 +14,6 @@ This section contains product manual content for each component in Camunda Cloud
 - [Zeebe Engine](zeebe/zeebe-overview.md) - Complete documentation for Zeebe. 
 - [Operate](operate/index.md) - User and deployment guide for Operate.
 - [Tasklist](tasklist/deployment/configuration.md) - Deployment guide for Tasklist.
-- [IAM](iam/overview.md) - Documentation covering the IAM offering.
+- [IAM](iam/what-is-iam.md) - Documentation covering the IAM offering.
 
 While Camunda Cloud is cloud-first, applicable sections like Zeebe Engine include self-managed operation steps.

--- a/sidebars.js
+++ b/sidebars.js
@@ -273,7 +273,7 @@ module.exports = {
         },
       ],
       IAM: [
-      "components/iam/overview", {
+      "components/iam/what-is-iam", {
           "Third-Party Libraries": [
             "components/iam/third-party-libraries/backend-third-party-libraries",
             "components/iam/third-party-libraries/frontend-third-party-libraries"

--- a/static/.htaccess
+++ b/static/.htaccess
@@ -7,5 +7,8 @@ RewriteRule (.*) https://%{SERVER_NAME}/$1 [R=301,L]
 Options -Indexes
 
 # Redirect pages - https://httpd.apache.org/docs/current/mod/mod_rewrite.html#rewriterule
+RewriteRule ^docs/product-manuals/iam/overview$ /docs/components/iam/what-is-iam [R=301,L]
+RewriteRule ^docs/components/iam/overview$ /docs/components/iam/what-is-iam [R=301,L]
+
 RewriteRule ^docs/product-manuals/(.*)$ /docs/components/$1 [R=301,L]
 RewriteRule ^docs/product-manuals$ /docs/components/ [R=301,L]


### PR DESCRIPTION
I would like to rename the IAM landing page from something generic to something a little more inviting. Therefore I decided to go with `What is IAM?` which is a clear sign post to a user that within the page they will find out what IAM actually is and the role it plays.