### PR TITLE
Updated link to maintained/default docker-compose file

### DIFF
--- a/docs/components/zeebe/deployment-guide/docker/install.md
+++ b/docs/components/zeebe/deployment-guide/docker/install.md
@@ -18,7 +18,7 @@ The easiest way to develop with Zeebe is using Docker. Docker provides a consist
 
 ### Docker configurations for docker-compose
 
-A default docker compose configuration to run Zeebe, Operate and Tasklist is available in the get started repository: [https://github.com/camunda-cloud/camunda-cloud-get-started/blob/master/docker-compose.yaml](docker-compose.yaml).
+A default docker compose configuration to run Zeebe, Operate and Tasklist is available in the get started repository: [docker-compose.yaml](https://github.com/camunda-cloud/camunda-cloud-get-started/blob/master/docker-compose.yaml).
 
 Download this file to your local computer, `cd` into that directory and run `docker compose up`. 
 
@@ -27,8 +27,8 @@ Some more information on Zeebe using `docker-compose`, including more specific c
 #### Exposed ports
 
 - `26500`: Zeebe Gateway API
-- [http://localhost:8080/](`8080`): Operate
-- [http://localhost:8080/](`8081`): Tasklist
+- [`8080`](http://localhost:8080/): Operate
+- [`8081`](http://localhost:8080/): Tasklist
 
 
 ### Using Docker without docker-compose

--- a/docs/components/zeebe/deployment-guide/docker/install.md
+++ b/docs/components/zeebe/deployment-guide/docker/install.md
@@ -18,18 +18,18 @@ The easiest way to develop with Zeebe is using Docker. Docker provides a consist
 
 ### Docker configurations for docker-compose
 
-Docker configurations for starting Zeebe using `docker-compose` are available in the [zeebe-docker-compose](https://github.com/zeebe-io/zeebe-docker-compose/blob/master/README.md) repository.
+A default docker compose configuration to run Zeebe, Operate and Tasklist is available in the get started repository: [https://github.com/camunda-cloud/camunda-cloud-get-started/blob/master/docker-compose.yaml](docker-compose.yaml).
 
-This repository contains several pre-defined configuration options:
+Download this file to your local computer, `cd` into that directory and run `docker compose up`. 
 
-- Single node
-- Small cluster with and without gateway
-- Single node with Operate
-- Single node with simple monitor
+Some more information on Zeebe using `docker-compose`, including more specific configurations, are available in the [zeebe-docker-compose](https://github.com/zeebe-io/zeebe-docker-compose/blob/master/README.md) community extension.
 
-This allows you to start using complex configurations with a single command. You can tailor these configurations to your needs whenever you'd like.
+#### Exposed ports
 
-Further instructions for using these configurations are in the [README](https://github.com/zeebe-io/zeebe-docker-compose/blob/master/README.md).
+- `26500`: Zeebe Gateway API
+- [http://localhost:8080/](`8080`): Operate
+- [http://localhost:8080/](`8081`): Tasklist
+
 
 ### Using Docker without docker-compose
 


### PR DESCRIPTION
Looking at the installation docs we are currently discussion, I recognized that the docs point to the community extension around docker-compose, which is quite outdated at the moment (old Zeebe versions, no tasklist, ...).

At the same time, the Zeebe team maintains one docker-compose file always using the latest version: https://github.com/camunda-cloud/camunda-cloud-get-started/blob/master/docker-compose.yaml - so we should simply point to this one instead.