### PR TITLE
feat: add page for making iam production ready

### DIFF
--- a/docs/self-managed/iam/deployment/making-iam-production-ready.md
+++ b/docs/self-managed/iam/deployment/making-iam-production-ready.md
@@ -29,3 +29,18 @@ to a JSON formatted output from a signing key generator.
 Unsure how to generate a JSON Web Key? We'd recommend looking at the 
 [Nimbus JOSE + JWT documentation](https://connect2id.com/products/nimbus-jose-jwt/generator) for examples.
 :::
+
+### Enable access control
+The IAM component is capable of enforcing access control although by default this functionality is disabled.
+When access control is disabled, all users, regardless of role and permission assignment, will be able to manage users, roles, and permissions.
+
+To enable access control, set the `ENFORCE_ACCESS_CONTROL` environmental value to `true`
+
+### Configure IAM host URLs
+The IAM component by default exposes the service on `http://localhost:8080`.
+
+To change the location that the IAM component is served from, set `FRONTEND_URL`, `BACKEND_URL`, and `TOKEN_ISSUER` to your chosen URL.
+
+:::note
+The `BACKEND_URL` must be followed by `/api` for example, `http://localhost:8080/api`.
+:::

--- a/docs/self-managed/iam/deployment/making-iam-production-ready.md
+++ b/docs/self-managed/iam/deployment/making-iam-production-ready.md
@@ -1,0 +1,31 @@
+---
+id: making-iam-production-ready
+title: "Making IAM production ready"
+sidebar_label: "Making IAM production ready"
+---
+
+The IAM component offers a quick start method to enable you to get up and running as soon as possible. This means that
+there are a couple of tasks that we take care of to remove some production level complexity, to make sure that your IAM
+instance is ready to be used in a production setting we suggest you perform the following tasks.
+
+### Set the database encryption key variable
+The IAM component stores certain information that requires encryption, by default during each start of the IAM service 
+if no value is set for the `DATABASE_ENCRYPTION_KEY` environmental variable a value is generated. 
+
+To maintain a consistent value, set the `DATABASE_ENCRYPTION_KEY` environmental variable to an alpha-numeric string.
+
+:::tip
+We would suggest that the length of the string is 32 characters.
+:::
+
+### Set the token signing key variable
+The IAM component generates authentication tokens, to be able to do this a signing key needs to be used, by default 
+during each start of the IAM service if no signing key is provided one will be automatically generated. 
+
+To be able to use authentication tokens generated before a service restart, set the `TOKEN_SIGNING_KEY` environmental value
+to a JSON formatted output from a signing key generator.
+
+:::tip
+Unsure how to generate a JSON Web Key? We'd recommend looking at the 
+[Nimbus JOSE + JWT documentation](https://connect2id.com/products/nimbus-jose-jwt/generator) for examples.
+:::

--- a/docs/self-managed/iam/deployment/making-iam-production-ready.md
+++ b/docs/self-managed/iam/deployment/making-iam-production-ready.md
@@ -1,46 +1,46 @@
 ---
 id: making-iam-production-ready
-title: "Making IAM production ready"
-sidebar_label: "Making IAM production ready"
+title: "Making IAM production-ready"
+sidebar_label: "Making IAM production-ready"
 ---
 
-The IAM component offers a quick start method to enable you to get up and running as soon as possible. This means that
-there are a couple of tasks that we take care of to remove some production level complexity, to make sure that your IAM
-instance is ready to be used in a production setting we suggest you perform the following tasks.
+The IAM component offers a quick start method to swiftly get up and running. This means we handle a few tasks to remove production level complexity. To ensure your IAM instance is ready for use in a production setting, we suggest performing the following tasks.
 
 ### Set the database encryption key variable
-The IAM component stores certain information that requires encryption, by default during each start of the IAM service 
-if no value is set for the `DATABASE_ENCRYPTION_KEY` environmental variable a value is generated. 
+
+The IAM component stores certain information requiring encryption. By default, if no value is set for the `DATABASE_ENCRYPTION_KEY` environmental variable during each start of the IAM service, a value is generated. 
 
 To maintain a consistent value, set the `DATABASE_ENCRYPTION_KEY` environmental variable to an alpha-numeric string.
 
 :::tip
-We would suggest that the length of the string is 32 characters.
+We suggest a string length of 32 characters.
 :::
 
 ### Set the token signing key variable
-The IAM component generates authentication tokens, to be able to do this a signing key needs to be used, by default 
-during each start of the IAM service if no signing key is provided one will be automatically generated. 
 
-To be able to use authentication tokens generated before a service restart, set the `TOKEN_SIGNING_KEY` environmental value
+The IAM component generates authentication tokens. To do this, a signing key must be used. By default, if no signing key is provided during each start of the IAM service, one is automatically generated. 
+
+To use authentication tokens generated before a service restart, set the `TOKEN_SIGNING_KEY` environmental value
 to a JSON formatted output from a signing key generator.
 
 :::tip
-Unsure how to generate a JSON Web Key? We'd recommend looking at the 
+Unsure how to generate a JSON Web Key? Visit the 
 [Nimbus JOSE + JWT documentation](https://connect2id.com/products/nimbus-jose-jwt/generator) for examples.
 :::
 
 ### Enable access control
-The IAM component is capable of enforcing access control although by default this functionality is disabled.
-When access control is disabled, all users, regardless of role and permission assignment, will be able to manage users, roles, and permissions.
 
-To enable access control, set the `ENFORCE_ACCESS_CONTROL` environmental value to `true`
+The IAM component is capable of enforcing access control. However, this functionality is disabled by default.
+When access control is disabled, all users, regardless of role and permission assignment, are able to manage users, roles, and permissions.
+
+To enable access control, set the `ENFORCE_ACCESS_CONTROL` environmental value to `true`.
 
 ### Configure IAM host URLs
-The IAM component by default exposes the service on `http://localhost:8080`.
 
-To change the location that the IAM component is served from, set `FRONTEND_URL`, `BACKEND_URL`, and `TOKEN_ISSUER` to your chosen URL.
+By default, The IAM component exposes the service on `http://localhost:8080`.
+
+To change the location the IAM component is served from, set `FRONTEND_URL`, `BACKEND_URL`, and `TOKEN_ISSUER` to your chosen URL.
 
 :::note
-The `BACKEND_URL` must be followed by `/api` for example, `http://localhost:8080/api`.
+The `BACKEND_URL` must be followed by `/api`. For example, `http://localhost:8080/api`.
 :::

--- a/sidebars.js
+++ b/sidebars.js
@@ -314,6 +314,7 @@ module.exports = {
           }, {
             "Deployment": [
               "self-managed/iam/deployment/configuration-variables",
+              "self-managed/iam/deployment/making-iam-production-ready",
             ],
           }, {
           "Third-Party Libraries": [


### PR DESCRIPTION
Solves https://github.com/camunda-cloud/camunda-cloud-documentation/issues/394

To make sure that users are aware that there are certain steps they should take to make the IAM component stable for production uses. At present the only variables that need to be considered are `DATABASE_ENCRYPTION_KEY` and `TOKEN_SIGNING_KEY`