### PR TITLE
feat: add to list of environmental variables

### DIFF
--- a/docs/self-managed/iam/deployment/configuration-variables.md
+++ b/docs/self-managed/iam/deployment/configuration-variables.md
@@ -16,8 +16,8 @@ FEATURE_LDAP | Toggle LDAP support within IAM | false
 
 Environment variable | Description | Default value
 -------|----------|-------
-ENFORCE_ACCESS_CONTROL | Controls the enforcing of permissions for the IAM component | false
-ENFORCE_HTTPS | Controls if the URLs supplied for client configurations have to be http/https. | true
+ENFORCE_ACCESS_CONTROL | Controls the enforcing of permissions for the IAM component, if set to false, all users can access user, role and permission management. | false
+ENFORCE_HTTPS | Controls if the URLs specified for client configuration must be `https://` | true
 
 ### LDAP 
 

--- a/docs/self-managed/iam/deployment/configuration-variables.md
+++ b/docs/self-managed/iam/deployment/configuration-variables.md
@@ -10,14 +10,14 @@ As IAM is a Spring Boot application, you may use the standard Spring [configurat
 
 Environment variable | Description | Default value
 -----|-------------|--------------
-FEATURE_LDAP | Toggle LDAP support within IAM | false
+FEATURE_LDAP | Toggle LDAP support within IAM. | false
 
 ### Functionality
 
 Environment variable | Description | Default value
 -------|----------|-------
-ENFORCE_ACCESS_CONTROL | Controls the enforcing of permissions for the IAM component, if set to false, all users can access user, role and permission management. | false
-ENFORCE_HTTPS | Controls if the URLs specified for client configuration must be `https://` | true
+ENFORCE_ACCESS_CONTROL | Controls enforcement of permissions for the IAM component. If set to false, all users can access user, role, and permission management. | false
+ENFORCE_HTTPS | Controls if the URLs specified for client configuration must be `https://`. | true
 
 ### LDAP 
 

--- a/docs/self-managed/iam/deployment/configuration-variables.md
+++ b/docs/self-managed/iam/deployment/configuration-variables.md
@@ -12,6 +12,13 @@ Environment variable | Description | Default value
 -----|-------------|--------------
 FEATURE_LDAP | Toggle LDAP support within IAM | false
 
+### Functionality
+
+Environment variable | Description | Default value
+-------|----------|-------
+ENFORCE_ACCESS_CONTROL | Controls the enforcing of permissions for the IAM component | false
+ENFORCE_HTTPS | Controls if the URLs supplied for client configurations have to be http/https. | true
+
 ### LDAP 
 
 All LDAP properties are prefixed with `LDAP_`.


### PR DESCRIPTION
Solves https://github.com/camunda-cloud/camunda-cloud-documentation/issues/390

I noticed in the forums that there were a couple of configuration variables that aren't as clear as they should be, notably `ENFORCE_HTTPS` and `ENFORCE_ACCESS_CONTROL`