### PR TITLE
Announce deprecation of `zeebe-test`

### DIFF
--- a/docs/apis-clients/java-client/testing.md
+++ b/docs/apis-clients/java-client/testing.md
@@ -4,6 +4,10 @@ title: "Writing tests"
 ---
 You can use the `zeebe-test` module to write JUnit tests for your job worker and BPMN process. This provides a JUnit rule to bootstrap the broker and some basic assertions.
 
+:::note
+`zeebe-test` is [deprecated for removal](./reference/announcements.md).
+:::
+
 ## Usage in a Maven project
 
 Add `zeebe-test` as a Maven test dependency to your project:

--- a/docs/reference/announcements.md
+++ b/docs/reference/announcements.md
@@ -35,3 +35,7 @@ In terms of specifying values, there were two minor changes:
 ## Removed in 1.0
 
 The support for YAML processes was removed as of release 1.0. The `resourceType` in Deployment record and Process grpc request are deprecated; they will always contain `BPMN` as value.
+
+## Deprecated in 1.3
+
+The `zeebe-test` module was deprecated in 1.3.0. We are currently planning to remove `zeebe-test` for the 1.4.0 release.


### PR DESCRIPTION
We are deprecating `zeebe-test`: https://github.com/camunda-cloud/zeebe/issues/8143. We have already started to work on [a replacement](https://github.com/camunda-cloud/camunda-cloud-testing) but I've not mentioned that in the deprecation announcement because it's not finished yet.

@akeller This is my first documentation contribution so I'm happy to receive any suggestions. We can also discuss if you'd prefer we add more information to the announcement, for example a link to the new `camunda-cloud-testing` project.