### PR TITLE
clarify java client cloud bootstrap

### DIFF
--- a/docs/apis-clients/java-client/index.md
+++ b/docs/apis-clients/java-client/index.md
@@ -44,6 +44,7 @@ In Java code, instantiate the client via the **ZeebeClientCloudBuilder** as foll
             .withClusterId(clusterId)
             .withClientId(clientId)
             .withClientSecret(clientSecret)
+            .withRegion("bru-2")
             .build();
 
     cloudClient.newTopologyRequest().send().join();

--- a/docs/apis-clients/java-client/index.md
+++ b/docs/apis-clients/java-client/index.md
@@ -29,45 +29,38 @@ Use the latest released version from [Maven Central](https://search.maven.org/ar
 
 If you build a Spring or Spring Boot application, you might want to use [Spring Zeebe](../../community-clients/spring) instead of handling the lifecycle and configuration of the Java client yourself (as described in the following paragraphs).
 
-## Bootstrapping
+## Bootstrapping for Camunda Cloud
 
-In Java code, instantiate the client as follows:
+In Java code, instantiate the client via the **ZeebeClientCloudBuilder** as follows:
 
 ```java
-  private static final String zeebeAPI = "[Zeebe API]";
+  private static final String clusterId = "[Cluster ID]"
   private static final String clientId = "[Client ID]";
   private static final String clientSecret = "[Client Secret]";
-  private static final String oAuthAPI = "[OAuth API] ";
-
+ 
   public static void main(String[] args) {
-    OAuthCredentialsProvider credentialsProvider =
-        new OAuthCredentialsProviderBuilder()
-            .authorizationServerUrl(oAuthAPI)
-            .audience(zeebeAPI)
-            .clientId(clientId)
-            .clientSecret(clientSecret)
+    ZeebeClient cloudClient =
+        ZeebeClient.newCloudClientBuilder()
+            .withClusterId(clusterId)
+            .withClientId(clientId)
+            .withClientSecret(clientSecret)
             .build();
 
-    ZeebeClient client =
-        ZeebeClient.newClientBuilder()
-            .gatewayAddress(zeebeAPI)
-            .credentialsProvider(credentialsProvider)
-            .build();
-
-    client.newTopologyRequest().send().join();
+    cloudClient.newTopologyRequest().send().join();
   }
 ```
 
 Let's go over this code snippet line by line:
 
-1. Declare a few variables to define the connection properties. These values can be taken from the connection information on the **Client Credentials** page. Note that `clientSecret` is only visible when you create the client credentials.
-2. Create the credentials provider for the OAuth protocol. This is needed to authenticate your client.
-3. Create the client by passing in the address of the cluster we want to connect to and the credentials provider from the step above.
+1. Declare a few variables to define the connection properties. The `clusterId` can be found in the **Cloud Console** under **Cluster Details**. The other values can be taken from the connection information on the **Client Credentials** page. Note that `clientSecret` is only visible when you create the client credentials.
+2. Create the client by passing the connection details into the Cloud client builder.
 4. Send a test request to verify the connection was established.
 
 See [io.camunda.zeebe.client.ZeebeClientBuilder](https://javadoc.io/doc/io.zeebe/zeebe-client-java/latest/io/zeebe/client/ZeebeClientBuilder.html) for a description of all available configuration properties.
 
-Another (more compact) option is to pass in the connection settings via environment variables:
+## Bootstrapping for Self-Managed
+
+Another option is to pass in the connection settings via environment variables:
 
 ```bash
 export ZEEBE_ADDRESS='[Zeebe API]'
@@ -78,7 +71,7 @@ export ZEEBE_AUTHORIZATION_SERVER_URL='[OAuth API]'
 
 When you create client credentials in Camunda Cloud, you have the option to download a file with the lines above filled out for you.
 
-Given these environment variables, you can instantiate the client as follows:
+Given these environment variables, you can instantiate the client with the **ClientBuilder** as follows:
 
 ```java
 ZeebeClient client =
@@ -91,7 +84,7 @@ ZeebeClient client =
 
 - [Getting Started Guide](https://github.com/camunda-cloud/camunda-cloud-get-started): A comprehensive tutorial that covers Camunda Modeler, Operate, and the Java client.
 
-[//]:# (Should we link to the desktop browser version of the gettin started guide here?)
+[//]:# "Should we link to the desktop browser version of the gettin started guide here?"
 
 - [Job worker](job-worker.md): An introduction to the Java client's job worker.
 - [Logging](logging.md): An introduction to configuring logging for a Zeebe client.


### PR DESCRIPTION
Hi, I had difficultites bootstrapping my Java Client against my Camunda Cloud cluster. You can find the details of the problem and two solutions in this forum post: https://forum.camunda.io/t/bootstrap-java-worker-failed-with-unrecognized-field-refreshtoken/2610

After I got it running, I started to correct the docs. I would like to reference them directly in exercises in Camunda Academy.

My questions: 
* Is my change a valid improvement? 
* What is the best way to bootstrap a java client?
* Where can I find the current Java-Docs?

As I would like to link the Java Docs, I found that the link used in this page: https://javadoc.io/doc/io.zeebe/zeebe-client-java/latest/io/zeebe/client/ZeebeClientBuilder.html only has a version 1.0.0-alpha7 as latest version.

I would like to replace the bold class names with a link to the classes used to configure the client.

