### PR TITLE
Add link checker workflow and rewrite rule for trailing slash issue

### DIFF
--- a/.github/workflows/linkcheck.yaml
+++ b/.github/workflows/linkcheck.yaml
@@ -1,0 +1,18 @@
+name: Check Links
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "* 22 * * *"
+
+jobs:
+  linkChecker:
+    name: Check links for url ${{ matrix.url }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        url: [ "https://docs.camunda.io", "https://stage.docs.camunda.io" ]
+    steps:
+      - uses: filiph/linkcheck@v2.0.15+1
+        with:
+          arguments: ${{ matrix.url }}

--- a/static/.htaccess
+++ b/static/.htaccess
@@ -38,3 +38,6 @@ RewriteRule ^docs/components/iam/overview$ /docs/components/iam/what-is-iam [R=3
 
 RewriteRule ^docs/product-manuals/(.*)$ /docs/components/$1 [R=301,L]
 RewriteRule ^docs/product-manuals$ /docs/components/ [R=301,L]
+
+# workaround for 404 with trailing slashes https://github.com/camunda-cloud/camunda-cloud-documentation/issues/403
+RewriteRule ^(.*(yaml|bpmn|xml|png|jpeg|jpg|yml|svg))/$ $1 [R=301,L]


### PR DESCRIPTION
This change set adds a new github workflow to check internal links in production and stage docs website, it is run every night at 22:00. Right now this doesn't fail anything and is more for us a way of understanding what the current state is. We can discuss how to move forward with this, but at least it allows us now to spot such issues easier.

Additionally this change contains a new rewrite rule to redirect any resource like bpmn, yaml, xml and images to remove the trailing slash.

closes #403
closes #419  