### PR TITLE
Describe assignment definitions for user tasks

### DIFF
--- a/docs/components/modeler/bpmn/user-tasks/user-tasks.md
+++ b/docs/components/modeler/bpmn/user-tasks/user-tasks.md
@@ -37,7 +37,7 @@ attributes can be specified simultaneously:
 Typically, the assignee and candidate groups are defined as static values (e.g. `some_username` and
 `sales, operations`), but they can also be defined as
 [expressions](/components/concepts/expressions.md) (e.g. `= book.author` and `= remove(reviewers,
-book.author)`). The expressiosn are evaluated on activating the user task and must result in a
+book.author)`). The expressions are evaluated on activating the user task and must result in a
 `string` for the assignee and a `list of strings` for the candidate groups.
 
 ## Variable mappings

--- a/docs/components/modeler/bpmn/user-tasks/user-tasks.md
+++ b/docs/components/modeler/bpmn/user-tasks/user-tasks.md
@@ -68,7 +68,7 @@ A user task with a user task form and an assignment definition:
   </bpmn:extensionElements>
   <bpmn:userTask id="Activity_025dulo" name="Configure">
     <bpmn:extensionElements>
-      <zeebe:assignmentDefinition assignee="= default_controller" candidateGroups="controllers" />
+      <zeebe:assignmentDefinition assignee="= default_controller" candidateGroups="controllers, auditors" />
       <zeebe:formDefinition formKey="camunda-forms:bpmn:userTaskForm_2g7iho6" />
     </bpmn:extensionElements>
   </bpmn:userTask>

--- a/docs/components/modeler/bpmn/user-tasks/user-tasks.md
+++ b/docs/components/modeler/bpmn/user-tasks/user-tasks.md
@@ -91,3 +91,7 @@ A user task with a user task form and an assignment definition:
 - [Tasklist](/components/tasklist/introduction.md)
 - [Job handling](/components/concepts/job-workers.md)
 - [Variable mappings](/components/concepts/variables.md#inputoutput-variable-mappings)
+
+
+
+[Tasklist]: /components/tasklist/introduction.md

--- a/docs/components/modeler/bpmn/user-tasks/user-tasks.md
+++ b/docs/components/modeler/bpmn/user-tasks/user-tasks.md
@@ -40,6 +40,17 @@ Typically, the assignee and candidate groups are defined as static values (e.g. 
 book.author)`). The expressions are evaluated on activating the user task and must result in a
 `string` for the assignee and a `list of strings` for the candidate groups.
 
+In order for [Tasklist](/components/tasklist/introduction.md) to claim the task for a known Tasklist user, 
+the value of the `assignee` must be the user's **unique identifier**.
+The unique identifier depends on the authentication method used to login to Tasklist:
+- Camunda Cloud (login with email, Google, GitHub): `email`
+- Default Basic Auth (elasticsearch): `username`
+- IAM: `username`
+
+:::info
+Example: You log in to Tasklist using Camunda Cloud login with email using your emailadres `foo@bar.com`. Every time a user task activates with `assignee` set to value `foo@bar.com`, Tasklist automatically assigns it to you. You'll be able to find your new task under the task dropdown option `Claimed by me`.
+:::
+
 ## Variable mappings
 
 By default, all job variables are merged into the process instance. This

--- a/docs/components/modeler/bpmn/user-tasks/user-tasks.md
+++ b/docs/components/modeler/bpmn/user-tasks/user-tasks.md
@@ -27,6 +27,19 @@ embedded [Camunda Forms](../../../../guides/utilizing-forms.md),
 these can be embedded into the BPMN process XML as a `zeebe:UserTaskForm`
 extension element of the process element.
 
+## Assignments
+User tasks support specifying assignments, using the `zeebe:AssignmentDefinition` extension element.
+This can be used to define which user the task can be assigned to. One or both of the following
+attributes can be specified simultaneously:
+- `assignee`: Specifies the user assigned to the task. [Tasklist] will claim the task for this user.
+- `candidateGroups`: Specifies the groups of users that the task can be assigned to.
+
+Typically, the assignee and candidate groups are defined as static values (e.g. `some_username` and
+`sales, operations`), but they can also be defined as
+[expressions](/components/concepts/expressions.md) (e.g. `= book.author` and `= remove(reviewers,
+book.author)`). The expressiosn are evaluated on activating the user task and must result in a
+`string` for the assignee and a `list of strings` for the candidate groups.
+
 ## Variable mappings
 
 By default, all job variables are merged into the process instance. This
@@ -44,7 +57,7 @@ as configuration parameters for the worker.
 
 ### XML representation
 
-A user task with a user task form:
+A user task with a user task form and an assignment definition:
 
 ```xml
 <bpmn:process id="controlProcess" name="Control Process" isExecutable="true">
@@ -55,6 +68,7 @@ A user task with a user task form:
   </bpmn:extensionElements>
   <bpmn:userTask id="Activity_025dulo" name="Configure">
     <bpmn:extensionElements>
+      <zeebe:assignmentDefinition assignee="= default_controller" candidateGroups="controllers" />
       <zeebe:formDefinition formKey="camunda-forms:bpmn:userTaskForm_2g7iho6" />
     </bpmn:extensionElements>
   </bpmn:userTask>


### PR DESCRIPTION
This adds a description of how assignments can be defined for user tasks.

This documentation is part of https://github.com/camunda-cloud/zeebe/issues/8020 (currently planned for release 1.3).

The full spec of assignment definitions can be found here: https://github.com/camunda-cloud/zeebe/issues/8053.

closes #463
relates to #454 