### PR TITLE
Add YAML mime type

### DIFF
--- a/static/.htaccess
+++ b/static/.htaccess
@@ -46,3 +46,7 @@ RewriteRule ^docs/product-manuals$ /docs/components/ [R=301,L]
 
 # workaround for 404 with trailing slashes https://github.com/camunda-cloud/camunda-cloud-documentation/issues/403
 RewriteRule ^(.*(yaml|bpmn|xml|png|jpeg|jpg|yml|svg))/$ /$1 [R=301,L]
+
+
+# Add yaml mime type
+AddType text/vnd.yaml   yaml


### PR DESCRIPTION
This change is not necessary and there is no official mime type for yaml (see #478) but it would remove the warning from our link checker and it adds a content-type if anyone opens a yaml file in our docs.

closes #478