### PR TITLE
Fix wrong anchor links and add link checker to docs build workflow

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -20,3 +20,18 @@ jobs:
         run: npm ci
       - name: Build
         run: npm run build
+      - name: Remove https redirect
+        run: |
+          sed -i '/SERVER_PORT/d;/SERVER_NAME/d' build/.htaccess
+      - name: Run web server
+        run: |
+          docker run -d --name webserver -v "$PWD/build":/app -p 8888:8080 bitnami/apache:latest
+          echo "container_ip=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' webserver)" >> $GITHUB_ENV
+      - name: Waiting for URL available
+        uses: nev7n/wait_for_response@v1
+        with:
+          url: 'http://${{ env.container_ip }}:8080/'
+      - name: Check internal links
+        uses: filiph/linkcheck@v2.0.15+1
+        with:
+          arguments: 'http://${{ env.container_ip }}:8080'

--- a/docs/guides/getting-started-orchestrate-microservices.md
+++ b/docs/guides/getting-started-orchestrate-microservices.md
@@ -21,7 +21,7 @@ While this guide uses code snippets in Java, you do not need to be a Java develo
 
 First, [log in](https://camunda.io) to your Camunda Cloud account or [sign up](https://camunda.io/signup) if you still need one, then log in.
 
-1. [Design your process with BPMN](#design-your-process-with-BPMN)
+1. [Design your process with BPMN](#design-your-process-with-bpmn)
 2. [Create credentials for your Zeebe client](#create-credentials-for-your-zeebe-client)
 3. [Create a worker for the service task](#create-a-worker-for-the-service-task)
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -90,13 +90,13 @@ A job represents a distinct unit of work within a business process. Service task
 jobs in your process and are identified by a unique id. A job has a type to allow specific job
 workers to find jobs that they can work on.
 
-- [Job workers](/components/concepts/job-workers.md#what-is-a-job)
+- [Job workers](/components/concepts/job-workers.md)
 
 ### Job activation timeout
 
 This is the amount of time the broker will wait for a complete or fail response from the job worker. This comes after a job has been submitted to the job worker for processing and before it marks the job as available again for other job workers.
 
-- [Job workers](/components/concepts/job-workers.md#requesting-jobs-from-the-broker)
+- [Job workers](/components/concepts/job-workers.md#requesting-jobs)
 
 ### Job worker
 

--- a/docs/self-managed/operate-deployment/authentication.md
+++ b/docs/self-managed/operate-deployment/authentication.md
@@ -7,9 +7,8 @@ description: "Let's take a closer look at how Operate authenticates for use."
 Operate provides three ways to authenticate:
 
 1. User information stored in [Elasticsearch](#user-in-elasticsearch).
-2. [Camunda Cloud single sign-on](#camunda-cloud-single-sign-on).
-3. [Lightweight Directory Access Protocol (LDAP)](#ldap).
-4. [IAM Authentication and Authorization](#iam)
+2. [Lightweight Directory Access Protocol (LDAP)](#ldap).
+3. [IAM Authentication and Authorization](#iam)
 
 By default, user storage in Elasticsearch is enabled.
 

--- a/docs/self-managed/operate-deployment/schema-and-migration.md
+++ b/docs/self-managed/operate-deployment/schema-and-migration.md
@@ -7,7 +7,7 @@ Operate stores data in Elasticsearch. On first start, Operate creates all requir
 * [Schema](#schema)
 * [Data migration](#data-migration)
 * [How to migrate](#how-to-migrate)
-* [Example for migrate in Kubernetes](#example-for-migrate-in-kubernetes)
+* [Example for migration in Kubernetes](#example-for-migration-in-kubernetes)
 
 ## Schema
 

--- a/docs/self-managed/tasklist-deployment/authentication.md
+++ b/docs/self-managed/tasklist-deployment/authentication.md
@@ -7,7 +7,7 @@ description: "Let's take a closer look at the authentication methods of Tasklist
 Tasklist provides two ways to authenticate:
 
 1. User information stored in [Elasticsearch](#user-in-elasticsearch)
-2. [Camunda Cloud Single Sign-On](#camunda-cloud-single-sign-on)
+2. [IAM Authentication and Authorization](#iam)
 
 By default, user storage in Elasticsearch is enabled.
 

--- a/static/.htaccess
+++ b/static/.htaccess
@@ -63,3 +63,5 @@ RewriteRule ^(.*(yaml|bpmn|xml|png|jpeg|jpg|yml|svg))/$ /$1 [R=301,L]
 
 # Add yaml mime type
 AddType text/vnd.yaml   yaml
+# Add bpmn mime type
+AddType text/xml        bpmn

--- a/versioned_docs/version-0.25/components/operate/deployment/configuration.md
+++ b/versioned_docs/version-0.25/components/operate/deployment/configuration.md
@@ -16,7 +16,6 @@ with `camunda.operate`. The following parts are configurable:
  * [Scaling Operate](importer-and-archiver.md)
  * [Monitoring possibilities](#monitoring-operate)
  * [Logging configuration](#logging)
- * [Probes](#probes)
 
 ## Configurations
 

--- a/versioned_docs/version-0.25/components/zeebe/clients/go-client/get-started.md
+++ b/versioned_docs/version-0.25/components/zeebe/clients/go-client/get-started.md
@@ -12,7 +12,6 @@ You will be guided through the following steps:
 * [Deploy a workflow](#deploy-a-workflow)
 * [Create a workflow instance](#create-a-workflow-instance)
 * [Work on a task](#work-on-a-task)
-* [Open a topic subscription](#open-a-topic-subscription)
 
 
 > You can find the complete source code, on [GitHub](https://github.com/zeebe-io/zeebe-get-started-go-client).

--- a/versioned_docs/version-0.25/components/zeebe/operations/upgrade-zeebe.md
+++ b/versioned_docs/version-0.25/components/zeebe/operations/upgrade-zeebe.md
@@ -90,7 +90,7 @@ The upgrade is successful if the following conditions are met:
 
 * the broker is ready (see [Ready Check](health.md#ready-check))
 * the broker is healthy (see [Health Check](health.md#health-check))
-* all partitions are healthy (see the [Metric](metrics.md#metrics-related-to-health) `zeebe_health`)
+* all partitions are healthy (see the [Metric](metrics.md#available-metrics) `zeebe_health`)
 * the stream processors of the partition leaders are in the phase `PROCESSING` (see [Partitions Admin Endpoint](#partitions-admin-endpoint))
 
 If the upgrade failed because of a known issue then a partition change its status to unhealthy, and the log output may contain the following error message:

--- a/versioned_docs/version-0.25/components/zeebe/yaml-workflows/data-flow.md
+++ b/versioned_docs/version-0.25/components/zeebe/yaml-workflows/data-flow.md
@@ -27,7 +27,7 @@ tasks:
       type: shipment-service
 ```
 
-Every mapping element has a `source` and a `target` element which must be a [variable expression](../reference/variables.md#access-variables).
+Every mapping element has a `source` and a `target` element which must be a [variable expression](../reference/variables.md).
 
 ## Additional Resources
 

--- a/versioned_docs/version-0.26/components/cloud-console/manage-plan/professional-plan/billing-parameters.md
+++ b/versioned_docs/version-0.26/components/cloud-console/manage-plan/professional-plan/billing-parameters.md
@@ -7,7 +7,7 @@ title: Billing parameters
 The terms under which the Professional Plan is available might change in the future.
 :::
 
-The Professional Plan has a fixed monthly subscription fee (_"Base Fee"_) as well as a variable, pay as you go component which depends on the amount of [cluster reservations](#managing-reservations) (_"Reservations Billing"_).
+The Professional Plan has a fixed monthly subscription fee (_"Base Fee"_) as well as a variable, pay as you go component which depends on the amount of [cluster reservations](../../../manage-organization/update-billing-reservations/#managing-reservations) (_"Reservations Billing"_).
 
 Reservations billing works as follows: for each day (GMT+2), the _daily total_ is calculated. To obtain the daily total, all reservations that were active on that day are recorded and for each such reservation, the daily price of the cluster type corresponding to that reservation is added. (Note: The daily price of a cluster type is obtained by dividing the monthly price of the cluster type by the numbers of days in the month). At the end of the month, the daily totals are added up to obtain the _monthly total_.
 

--- a/versioned_docs/version-0.26/components/zeebe/deployment-guide/operations/upgrade-zeebe.md
+++ b/versioned_docs/version-0.26/components/zeebe/deployment-guide/operations/upgrade-zeebe.md
@@ -90,7 +90,7 @@ The upgrade is successful if the following conditions are met:
 
 * the broker is ready (see [Ready Check](health.md#ready-check))
 * the broker is healthy (see [Health Check](health.md#health-check))
-* all partitions are healthy (see the [Metric](metrics.md#metrics-related-to-health) `zeebe_health`)
+* all partitions are healthy (see the [Metric](metrics.md#available-metrics) `zeebe_health`)
 * the stream processors of the partition leaders are in the phase `PROCESSING` (see [Partitions Admin Endpoint](#partitions-admin-endpoint))
 
 If the upgrade failed because of a known issue then a partition change its status to unhealthy, and the log output may contain the following error message:

--- a/versioned_docs/version-0.26/reference/glossary.md
+++ b/versioned_docs/version-0.26/reference/glossary.md
@@ -83,13 +83,13 @@ A job represents a distinct unit of work within a business process. Service task
 jobs in your workflow and are identified by a unique id. A job has a type to allow specific job
 workers to find jobs that they can work on.
 
-- [Job workers](/components/concepts/job-workers.md#what-is-a-job)
+- [Job workers](/components/concepts/job-workers.md)
 
 ### Job activation timeout
 
 This is the amount of time the broker will wait for a complete or fail response from the job worker after a job has been submitted to the job worker for processing before it marks the job as available again for other job workers.
 
-- [Job workers](/components/concepts/job-workers.md#requesting-jobs-from-the-broker)
+- [Job workers](/components/concepts/job-workers.md#requesting-jobs)
 
 ### Job worker
 

--- a/versioned_docs/version-1.0/components/operate/deployment/schema-and-migration.md
+++ b/versioned_docs/version-1.0/components/operate/deployment/schema-and-migration.md
@@ -7,7 +7,7 @@ Operate stores data in Elasticsearch. On first start Operate will create all req
 * [Schema](#schema)
 * [Data migration](#data-migration)
 * [How to migrate](#how-to-migrate)
-* [Example for migrate in Kubernetes](#example-for-migrate-in-kubernetes)
+* [Example for migration in Kubernetes](#example-for-migration-in-kubernetes)
 
 ## Schema
 

--- a/versioned_docs/version-1.0/reference/glossary.md
+++ b/versioned_docs/version-1.0/reference/glossary.md
@@ -91,13 +91,13 @@ A job represents a distinct unit of work within a business process. Service task
 jobs in your process and are identified by a unique id. A job has a type to allow specific job
 workers to find jobs that they can work on.
 
-- [Job workers](/components/concepts/job-workers.md#what-is-a-job)
+- [Job workers](/components/concepts/job-workers.md)
 
 ### Job activation timeout
 
 This is the amount of time the broker will wait for a complete or fail response from the job worker after a job has been submitted to the job worker for processing before it marks the job as available again for other job workers.
 
-- [Job workers](/components/concepts/job-workers.md#requesting-jobs-from-the-broker)
+- [Job workers](/components/concepts/job-workers.md#requesting-jobs)
 
 ### Job worker
 

--- a/versioned_docs/version-1.1/components/operate/deployment/schema-and-migration.md
+++ b/versioned_docs/version-1.1/components/operate/deployment/schema-and-migration.md
@@ -7,7 +7,7 @@ Operate stores data in Elasticsearch. On first start, Operate creates all requir
 * [Schema](#schema)
 * [Data migration](#data-migration)
 * [How to migrate](#how-to-migrate)
-* [Example for migrate in Kubernetes](#example-for-migrate-in-kubernetes)
+* [Example for migration in Kubernetes](#example-for-migration-in-kubernetes)
 
 ## Schema
 

--- a/versioned_docs/version-1.1/reference/glossary.md
+++ b/versioned_docs/version-1.1/reference/glossary.md
@@ -90,13 +90,13 @@ A job represents a distinct unit of work within a business process. Service task
 jobs in your process and are identified by a unique id. A job has a type to allow specific job
 workers to find jobs that they can work on.
 
-- [Job workers](/components/concepts/job-workers.md#what-is-a-job)
+- [Job workers](/components/concepts/job-workers.md)
 
 ### Job activation timeout
 
 This is the amount of time the broker will wait for a complete or fail response from the job worker. This comes after a job has been submitted to the job worker for processing and before it marks the job as available again for other job workers.
 
-- [Job workers](/components/concepts/job-workers.md#requesting-jobs-from-the-broker)
+- [Job workers](/components/concepts/job-workers.md#requesting-jobs)
 
 ### Job worker
 


### PR DESCRIPTION
This PR does two things to fix our internal link issues.

1. Add link check to build docs workflow to discover broken internal links before merge
    - adds steps to setup local apache webserver to test links
    - remove https redirect from htaccess to test locally
    - add mime type for bpmn, this is already configured in our prod apache  but is needed for the local test
2. Fix broken anchor links on master
    - remove non-existing anchor links
    - update anchors links to new locations
    - update links in all versions of docs

After we merge this PR we should be able to detect internal link issues before merging PRs. There is still the risk that external links are broken. I would opt not to check internal links on every PR, as that might be temporary issues and should block a PR, but I'm happy to be challenged on that. I will investigate to add external link check to our nightly check, to discover potential broken links in a timely manner.

