### PR TITLE
Enable Java syntax highlighting

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -29,6 +29,9 @@ module.exports = {
     ],
   ],
   themeConfig: {
+    prism: {
+      additionalLanguages: ['java'],
+    },
     navbar: {
       title: "Camunda Cloud Docs",
       logo: {


### PR DESCRIPTION
closes #495 

Enable Java syntax highlighting.
<img width="1006" alt="image" src="https://user-images.githubusercontent.com/5787702/145794392-0b98c7be-afbb-4e7f-b49a-c4ddff521b9a.png">
