### PR TITLE
fix(update-guide): add link to composable index templates

### DIFF
--- a/docs/guides/update-guide/026-to-100.md
+++ b/docs/guides/update-guide/026-to-100.md
@@ -45,9 +45,8 @@ The supported Elasticsearch version of the Elasticsearch Exporter was increased
 from `6.8` to `7.10`, read more about this in the
 [Elasticsearch](#elasticsearch) section.
 
-The index templates of the Elasticsearch Exporter were migrated to the
-
-[//]:# (Looks like this sentence wasn't completed. What should be added here?)
+The index templates of the Elasticsearch Exporter were migrated to use
+[composable index templates](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-templates.html).
 
 #### Protocol
 

--- a/versioned_docs/version-1.0/guides/update-guide/026-to-100.md
+++ b/versioned_docs/version-1.0/guides/update-guide/026-to-100.md
@@ -45,7 +45,9 @@ The supported Elasticsearch version of the Elasticsearch Exporter was increased
 from `6.8` to `7.10`, read more about this in the
 [Elasticsearch](#elasticsearch) section.
 
-The index templates of the Elasticsearch Exporter where migrated to the
+The index templates of the Elasticsearch Exporter were migrated to use
+[composable index templates](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-templates.html).
+
 
 #### Protocol
 

--- a/versioned_docs/version-1.1/guides/update-guide/026-to-100.md
+++ b/versioned_docs/version-1.1/guides/update-guide/026-to-100.md
@@ -43,9 +43,9 @@ The supported Elasticsearch version of the Elasticsearch Exporter was increased
 from `6.8` to `7.10`, read more about this in the
 [Elasticsearch](#elasticsearch) section.
 
-The index templates of the Elasticsearch Exporter were migrated to the
+The index templates of the Elasticsearch Exporter were migrated to use
+[composable index templates](https://www.elastic.co/guide/en/elasticsearch/reference/current/index-templates.html).
 
-[//]:# (Looks like this sentence wasn't completed. What should be added here?)
 
 #### Protocol
 


### PR DESCRIPTION
closes #460