### PR TITLE
Mixpanel Events: fix duplicate events

### DIFF
--- a/src/theme/Footer/index.js
+++ b/src/theme/Footer/index.js
@@ -162,7 +162,7 @@ const AnalyticsEvents = () => {
   );
 };
 
-let index = 0;
+let lastEventTs = 0;
 
 const MixpanelElement = () => {
   return (
@@ -199,7 +199,7 @@ const MixpanelElement = () => {
                     superProperties["org_id"] = orgId;
                   }
                   mixpanel.register(superProperties);
-                  mixpanel.track("docs");
+                  sendMixpanelEvent("docs");
                 }
               })
               .catch((_error) => {
@@ -207,9 +207,7 @@ const MixpanelElement = () => {
               });
           } else {
             // track event "docs"
-            console.log(`mixpanel event ${index}`);
-            mixpanel.track("docs");
-            index++;
+            sendMixpanelEvent("docs");
           }
         } else {
           // Osano is not or analytics consent is not enabled
@@ -219,6 +217,15 @@ const MixpanelElement = () => {
     </BrowserOnly>
   );
 };
+
+function sendMixpanelEvent(eventName) {
+  const now = Date.now();
+  if (now - lastEventTs > 1000) {
+    console.log(`mixpanel event ${index}`);
+    mixpanel.track(eventName);
+    lastEventTs = now;
+  }
+}
 
 const LoginButton = () => {
   const { loginWithRedirect } = useAuth0();

--- a/src/theme/Footer/index.js
+++ b/src/theme/Footer/index.js
@@ -154,7 +154,6 @@ const AnalyticsEvents = () => {
             redirectUri={auth0Config.origin}
           >
             <MixpanelElement></MixpanelElement>
-            <LoginButton></LoginButton>
           </Auth0Provider>
         );
       }}
@@ -219,18 +218,14 @@ const MixpanelElement = () => {
 };
 
 function sendMixpanelEvent(eventName) {
+  // somehow the code is executed twice
+  // that leads to the fact that events are sent twice
+  // workaround: send events only once per second
   const now = Date.now();
   if (now - lastEventTs > 1000) {
-    console.log(`mixpanel event ${index}`);
     mixpanel.track(eventName);
     lastEventTs = now;
   }
 }
-
-const LoginButton = () => {
-  const { loginWithRedirect } = useAuth0();
-
-  return <button onClick={() => loginWithRedirect()}>Log In</button>;
-};
 
 export default Footer;

--- a/src/theme/Footer/index.js
+++ b/src/theme/Footer/index.js
@@ -154,12 +154,15 @@ const AnalyticsEvents = () => {
             redirectUri={auth0Config.origin}
           >
             <MixpanelElement></MixpanelElement>
+            <LoginButton></LoginButton>
           </Auth0Provider>
         );
       }}
     </BrowserOnly>
   );
 };
+
+let index = 0;
 
 const MixpanelElement = () => {
   return (
@@ -204,7 +207,9 @@ const MixpanelElement = () => {
               });
           } else {
             // track event "docs"
+            console.log(`mixpanel event ${index}`);
             mixpanel.track("docs");
+            index++;
           }
         } else {
           // Osano is not or analytics consent is not enabled
@@ -213,6 +218,12 @@ const MixpanelElement = () => {
       }}
     </BrowserOnly>
   );
+};
+
+const LoginButton = () => {
+  const { loginWithRedirect } = useAuth0();
+
+  return <button onClick={() => loginWithRedirect()}>Log In</button>;
 };
 
 export default Footer;


### PR DESCRIPTION
Problem: Mixpanel events are sent twice, I think it's somewhere part of the react/docusaurus lifecycpe api
Workaround: send max one event per second