### PR TITLE
chore(go): bump go version and zbc import

### DIFF
--- a/docs/apis-clients/go-client/get-started.md
+++ b/docs/apis-clients/go-client/get-started.md
@@ -33,9 +33,9 @@ go mod init
 ```
 module github.com/zb-user/zb-example
 
-go 1.13
+go 1.17
 
-require github.com/zeebe-io/zeebe/clients/go v0.26.0
+require github.com/camunda-cloud/zeebe/clients/go v1.2.9
 ```
 
 3. Set the connection settings and client credentials as environment variables:
@@ -59,8 +59,8 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/zeebe-io/zeebe/clients/go/pkg/zbc"
-	"github.com/zeebe-io/zeebe/clients/go/pkg/pb"
+	"github.com/camunda-cloud/zeebe/clients/go/pkg/zbc"
+	"github.com/camunda-cloud/zeebe/clients/go/pkg/pb"
 	"os"
 )
 
@@ -224,9 +224,9 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/zeebe-io/zeebe/clients/go/pkg/entities"
-	"github.com/zeebe-io/zeebe/clients/go/pkg/worker"
-	"github.com/zeebe-io/zeebe/clients/go/pkg/zbc"
+	"github.com/camunda-cloud/zeebe/clients/go/pkg/entities"
+	"github.com/camunda-cloud/zeebe/clients/go/pkg/worker"
+	"github.com/camunda-cloud/zeebe/clients/go/pkg/zbc"
 	"log"
 	"os"
 )

--- a/docs/apis-clients/go-client/index.md
+++ b/docs/apis-clients/go-client/index.md
@@ -12,9 +12,9 @@ To use the Zeebe Go client library, add the following dependency to your `go.mod
 ```
 module github.com/zb-user/zb-example
 
-go 1.13
+go 1.17
 
-require github.com/zeebe-io/zeebe/clients/go v0.26.0
+require github.com/camunda-cloud/zeebe/clients/go v1.2.9
 ```
 
 ## Bootstrapping
@@ -27,7 +27,7 @@ package main
 import (
     "context"
     "fmt"
-    "github.com/zeebe-io/zeebe/clients/go/pkg/zbc"
+    "github.com/camunda-cloud/zeebe/clients/go/pkg/zbc"
 )
 
 func main() {
@@ -86,7 +86,7 @@ package main
 import (
     "context"
     "fmt"
-    "github.com/zeebe-io/zeebe/clients/go/pkg/zbc"
+    "github.com/camunda-cloud/zeebe/clients/go/pkg/zbc"
     "os"
 )
 

--- a/docs/self-managed/zeebe-deployment/security/client-authorization.md
+++ b/docs/self-managed/zeebe-deployment/security/client-authorization.md
@@ -66,7 +66,7 @@ import (
     "fmt"
     "google.golang.org/grpc/status"
     "google.golang.org/grpc/codes"
-    "github.com/zeebe-io/zeebe/clients/go/pkg/zbc"
+    "github.com/camunda-cloud/zeebe/clients/go/pkg/zbc"
 )
 
 type MyCredentialsProvider struct {
@@ -160,7 +160,7 @@ package main
 import (
     "context"
     "fmt"
-    "github.com/zeebe-io/zeebe/clients/go/pkg/zbc"
+    "github.com/camunda-cloud/zeebe/clients/go/pkg/zbc"
 )
 
 func main() {
@@ -200,7 +200,7 @@ package main
 import (
     "context"
     "fmt"
-    "github.com/zeebe-io/zeebe/clients/go/pkg/zbc"
+    "github.com/camunda-cloud/zeebe/clients/go/pkg/zbc"
 )
 
 func main() {

--- a/docs/self-managed/zeebe-deployment/security/secure-client-communication.md
+++ b/docs/self-managed/zeebe-deployment/security/secure-client-communication.md
@@ -76,7 +76,7 @@ Similarly to the Java client, if no CA certificate is specified, the client will
 package test
 
 import (
-	"github.com/zeebe-io/zeebe/clients/go/zbc"
+	"github.com/camunda-cloud/zeebe/clients/go/zbc"
 )
 
 
@@ -94,7 +94,7 @@ To disable TLS, execute the following:
 package test
 
 import (
-	"github.com/zeebe-io/zeebe/clients/go/zbc"
+	"github.com/camunda-cloud/zeebe/clients/go/zbc"
 )
 
 


### PR DESCRIPTION
I saw that the Go versions are quite out of date and use the old import path for the dependencies. 

closes #528 