### PR TITLE
Revert "chore(tasklist): update Graphql API docs (#518)"

### DIFF
--- a/docs/apis-clients/tasklist-api/directives/include.mdx
+++ b/docs/apis-clients/tasklist-api/directives/include.mdx
@@ -13,6 +13,6 @@ directive @include(
 
 ### Arguments
 
-#### `if` ([`Boolean`](/docs/apis-clients/tasklist-api/scalars/boolean))
+#### `if` ([`Boolean!`](/docs/apis-clients/tasklist-api/scalars/boolean))
 
 Included when true.

--- a/docs/apis-clients/tasklist-api/directives/skip.mdx
+++ b/docs/apis-clients/tasklist-api/directives/skip.mdx
@@ -13,6 +13,6 @@ directive @skip(
 
 ### Arguments
 
-#### `if` ([`Boolean`](/docs/apis-clients/tasklist-api/scalars/boolean))
+#### `if` ([`Boolean!`](/docs/apis-clients/tasklist-api/scalars/boolean))
 
 Skipped when true.

--- a/docs/apis-clients/tasklist-api/directives/specified-by.mdx
+++ b/docs/apis-clients/tasklist-api/directives/specified-by.mdx
@@ -13,6 +13,6 @@ directive @specifiedBy(
 
 ### Arguments
 
-#### `url` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
+#### `url` ([`String!`](/docs/apis-clients/tasklist-api/scalars/string))
 
 The URL that specifies the behaviour of this scalar.

--- a/docs/apis-clients/tasklist-api/generated.md
+++ b/docs/apis-clients/tasklist-api/generated.md
@@ -12,4 +12,4 @@ Use the docs in the sidebar to find out how to use the schema:
 - **Allowed operations**: queries and mutations.
 - **Schema-defined types**: scalars, objects, enums, interfaces, unions, and input objects.
 
-<small><i>Generated on 12/16/2021, 5:19:28 PM.</i></small>
+<small><i>Generated on October 05, 2021 at 11:08:36 AM.</i></small>

--- a/docs/apis-clients/tasklist-api/inputs/task-query.mdx
+++ b/docs/apis-clients/tasklist-api/inputs/task-query.mdx
@@ -10,7 +10,6 @@ type TaskQuery {
   state: TaskState
   assigned: Boolean
   assignee: String
-  candidateGroup: String
   pageSize: Int
   taskDefinitionId: String
   searchAfter: [String!]
@@ -34,10 +33,6 @@ Are the tasks assigned?
 
 Who is assigned to the tasks?
 
-#### `candidateGroup` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
-
-given group is in candidate groups list
-
 #### `pageSize` ([`Int`](/docs/apis-clients/tasklist-api/scalars/int))
 
 Size of tasks page (default: 50).
@@ -46,18 +41,18 @@ Size of tasks page (default: 50).
 
 Task definition ID - what's the BPMN flow node?
 
-#### `searchAfter` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
+#### `searchAfter` ([`[String!]`](/docs/apis-clients/tasklist-api/scalars/string))
 
 Array of values copied from `sortValues` of one of the tasks, query will return page of tasks going directly after this values plus same sort values.
 
-#### `searchAfterOrEqual` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
+#### `searchAfterOrEqual` ([`[String!]`](/docs/apis-clients/tasklist-api/scalars/string))
 
 Array of values copied from `sortValues` of one of the tasks, query will return page of tasks going directly after this values.
 
-#### `searchBefore` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
+#### `searchBefore` ([`[String!]`](/docs/apis-clients/tasklist-api/scalars/string))
 
 Array of values copied from `sortValues` of one of the tasks, query will return page of tasks going directly before this values plus same sort values.
 
-#### `searchBeforeOrEqual` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
+#### `searchBeforeOrEqual` ([`[String!]`](/docs/apis-clients/tasklist-api/scalars/string))
 
 Array of values copied from `sortValues` of one of the tasks, query will return page of tasks going directly before this values.

--- a/docs/apis-clients/tasklist-api/inputs/variable-input.mdx
+++ b/docs/apis-clients/tasklist-api/inputs/variable-input.mdx
@@ -14,6 +14,6 @@ type VariableInput {
 
 ### Fields
 
-#### `name` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
+#### `name` ([`String!`](/docs/apis-clients/tasklist-api/scalars/string))
 
-#### `value` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
+#### `value` ([`String!`](/docs/apis-clients/tasklist-api/scalars/string))

--- a/docs/apis-clients/tasklist-api/mutations/claim-task.mdx
+++ b/docs/apis-clients/tasklist-api/mutations/claim-task.mdx
@@ -15,7 +15,7 @@ claimTask(
 
 ### Arguments
 
-#### `taskId` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
+#### `taskId` ([`String!`](/docs/apis-clients/tasklist-api/scalars/string))
 
 #### `assignee` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
 

--- a/docs/apis-clients/tasklist-api/mutations/complete-task.mdx
+++ b/docs/apis-clients/tasklist-api/mutations/complete-task.mdx
@@ -15,9 +15,9 @@ completeTask(
 
 ### Arguments
 
-#### `taskId` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
+#### `taskId` ([`String!`](/docs/apis-clients/tasklist-api/scalars/string))
 
-#### `variables` ([`VariableInput`](/docs/apis-clients/tasklist-api/inputs/variable-input))
+#### `variables` ([`[VariableInput!]!`](/docs/apis-clients/tasklist-api/inputs/variable-input))
 
 ### Type
 

--- a/docs/apis-clients/tasklist-api/mutations/delete-process-instance.mdx
+++ b/docs/apis-clients/tasklist-api/mutations/delete-process-instance.mdx
@@ -14,7 +14,7 @@ deleteProcessInstance(
 
 ### Arguments
 
-#### `processInstanceId` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
+#### `processInstanceId` ([`String!`](/docs/apis-clients/tasklist-api/scalars/string))
 
 ### Type
 

--- a/docs/apis-clients/tasklist-api/mutations/unclaim-task.mdx
+++ b/docs/apis-clients/tasklist-api/mutations/unclaim-task.mdx
@@ -14,7 +14,7 @@ unclaimTask(
 
 ### Arguments
 
-#### `taskId` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
+#### `taskId` ([`String!`](/docs/apis-clients/tasklist-api/scalars/string))
 
 ### Type
 

--- a/docs/apis-clients/tasklist-api/objects/form.mdx
+++ b/docs/apis-clients/tasklist-api/objects/form.mdx
@@ -15,14 +15,14 @@ type Form {
 
 ### Fields
 
-#### `id` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
+#### `id` ([`String!`](/docs/apis-clients/tasklist-api/scalars/string))
 
 The unique identifier of the embedded form within one process
 
-#### `processDefinitionId` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
+#### `processDefinitionId` ([`String!`](/docs/apis-clients/tasklist-api/scalars/string))
 
 Reference to process definition
 
-#### `schema` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
+#### `schema` ([`String!`](/docs/apis-clients/tasklist-api/scalars/string))
 
 Form content

--- a/docs/apis-clients/tasklist-api/objects/task.mdx
+++ b/docs/apis-clients/tasklist-api/objects/task.mdx
@@ -20,29 +20,28 @@ type Task {
   isFirst: Boolean
   formKey: String
   processDefinitionId: String
-  candidateGroups: [String!]
 }
 ```
 
 ### Fields
 
-#### `id` ([`ID`](/docs/apis-clients/tasklist-api/scalars/id))
+#### `id` ([`ID!`](/docs/apis-clients/tasklist-api/scalars/id))
 
 The unique identifier of the task
 
-#### `name` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
+#### `name` ([`String!`](/docs/apis-clients/tasklist-api/scalars/string))
 
 Name of the task
 
-#### `taskDefinitionId` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
+#### `taskDefinitionId` ([`String!`](/docs/apis-clients/tasklist-api/scalars/string))
 
 Task Definition ID (node BPMN id) of the process
 
-#### `processName` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
+#### `processName` ([`String!`](/docs/apis-clients/tasklist-api/scalars/string))
 
 Name of the process
 
-#### `creationTime` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
+#### `creationTime` ([`String!`](/docs/apis-clients/tasklist-api/scalars/string))
 
 When was the task created
 
@@ -54,15 +53,15 @@ When was the task completed
 
 Username/id of who is assigned to the task
 
-#### `variables` ([`Variable`](/docs/apis-clients/tasklist-api/objects/variable))
+#### `variables` ([`[Variable!]`](/docs/apis-clients/tasklist-api/objects/variable))
 
 Variables associated to the task
 
-#### `taskState` ([`TaskState`](/docs/apis-clients/tasklist-api/enums/task-state))
+#### `taskState` ([`TaskState!`](/docs/apis-clients/tasklist-api/enums/task-state))
 
 State of the task
 
-#### `sortValues` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
+#### `sortValues` ([`[String!]`](/docs/apis-clients/tasklist-api/scalars/string))
 
 Array of values to be copied into `TaskQuery` to request for next or previous page of tasks.
 
@@ -77,7 +76,3 @@ Reference to the task form
 #### `processDefinitionId` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
 
 Reference to process definition
-
-#### `candidateGroups` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
-
-Candidate groups

--- a/docs/apis-clients/tasklist-api/objects/user.mdx
+++ b/docs/apis-clients/tasklist-api/objects/user.mdx
@@ -16,10 +16,10 @@ type User {
 
 ### Fields
 
-#### `username` ([`ID`](/docs/apis-clients/tasklist-api/scalars/id))
+#### `username` ([`ID!`](/docs/apis-clients/tasklist-api/scalars/id))
 
 #### `firstname` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
 
 #### `lastname` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
 
-#### `permissions` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
+#### `permissions` ([`[String!]`](/docs/apis-clients/tasklist-api/scalars/string))

--- a/docs/apis-clients/tasklist-api/objects/variable.mdx
+++ b/docs/apis-clients/tasklist-api/objects/variable.mdx
@@ -17,18 +17,18 @@ type Variable {
 
 ### Fields
 
-#### `id` ([`ID`](/docs/apis-clients/tasklist-api/scalars/id))
+#### `id` ([`ID!`](/docs/apis-clients/tasklist-api/scalars/id))
 
-#### `name` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
+#### `name` ([`String!`](/docs/apis-clients/tasklist-api/scalars/string))
 
-#### `value` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
+#### `value` ([`String!`](/docs/apis-clients/tasklist-api/scalars/string))
 
 full variable value
 
-#### `previewValue` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
+#### `previewValue` ([`String!`](/docs/apis-clients/tasklist-api/scalars/string))
 
 value preview (limited in size)
 
-#### `isValueTruncated` ([`Boolean`](/docs/apis-clients/tasklist-api/scalars/boolean))
+#### `isValueTruncated` ([`Boolean!`](/docs/apis-clients/tasklist-api/scalars/boolean))
 
 shows, whether previewValue contains truncated value or full value

--- a/docs/apis-clients/tasklist-api/queries/form.mdx
+++ b/docs/apis-clients/tasklist-api/queries/form.mdx
@@ -15,9 +15,9 @@ form(
 
 ### Arguments
 
-#### `id` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
+#### `id` ([`String!`](/docs/apis-clients/tasklist-api/scalars/string))
 
-#### `processDefinitionId` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
+#### `processDefinitionId` ([`String!`](/docs/apis-clients/tasklist-api/scalars/string))
 
 ### Type
 

--- a/docs/apis-clients/tasklist-api/queries/task.mdx
+++ b/docs/apis-clients/tasklist-api/queries/task.mdx
@@ -14,7 +14,7 @@ task(
 
 ### Arguments
 
-#### `id` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
+#### `id` ([`String!`](/docs/apis-clients/tasklist-api/scalars/string))
 
 ### Type
 

--- a/docs/apis-clients/tasklist-api/queries/tasks.mdx
+++ b/docs/apis-clients/tasklist-api/queries/tasks.mdx
@@ -14,7 +14,7 @@ tasks(
 
 ### Arguments
 
-#### `query` ([`TaskQuery`](/docs/apis-clients/tasklist-api/inputs/task-query))
+#### `query` ([`TaskQuery!`](/docs/apis-clients/tasklist-api/inputs/task-query))
 
 ### Type
 

--- a/docs/apis-clients/tasklist-api/queries/variable.mdx
+++ b/docs/apis-clients/tasklist-api/queries/variable.mdx
@@ -14,7 +14,7 @@ variable(
 
 ### Arguments
 
-#### `id` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
+#### `id` ([`String!`](/docs/apis-clients/tasklist-api/scalars/string))
 
 ### Type
 

--- a/docs/apis-clients/tasklist-api/queries/variables.mdx
+++ b/docs/apis-clients/tasklist-api/queries/variables.mdx
@@ -15,9 +15,9 @@ variables(
 
 ### Arguments
 
-#### `taskId` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
+#### `taskId` ([`String!`](/docs/apis-clients/tasklist-api/scalars/string))
 
-#### `variableNames` ([`String`](/docs/apis-clients/tasklist-api/scalars/string))
+#### `variableNames` ([`[String!]!`](/docs/apis-clients/tasklist-api/scalars/string))
 
 ### Type
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -13,17 +13,14 @@ module.exports = {
   // do not delete the following 'noIndex' line as it is modified for staging
   noIndex: false,
   plugins: [
-//        ["@edno/docusaurus2-graphql-doc-generator",
-//          {
-//            schema: "http://localhost:8080/tasklist/graphql",
-//            rootPath: "./docs/", // docs will be generated under (rootPath/baseURL)
-//            baseURL: "apis-clients/tasklist-api",
-//            linkRoot: "/docs/",
-//            loaders: {
-//              UrlLoader: "@graphql-tools/url-loader"
-//            }
-//          },
-//        ],
+    //    ["@edno/docusaurus2-graphql-doc-generator",
+    //      {
+    //        schema: "http://localhost:8080/tasklist/graphql",
+    //        rootPath: "./docs/", // docs will be generated under (rootPath/baseURL)
+    //        baseURL: "apis-clients/tasklist-api",
+    //        linkRoot: "/docs/"
+    //      },
+    //    ],
     [
       require.resolve("docusaurus-gtm-plugin"),
       {


### PR DESCRIPTION
Apparently we must merge the changes for upcoming version strictly AFTER the version was released. That's why I'm reverting it now.
This reverts commit f91941eb