### PR TITLE
feat(optimize): add ccsm configuration setup documentation

### DIFF
--- a/docs/self-managed/optimize-deployment/setup.md
+++ b/docs/self-managed/optimize-deployment/setup.md
@@ -1,0 +1,62 @@
+---
+id: setup
+title: "Self-Managed setup"
+description: "Install and configure Optimize Self-Managed."
+---
+
+## Install using Docker
+
+The `camunda/optimize:latest` docker image can be used to run Optimize in Self-Managed as a container. Certain environment
+variables need to be set for this to work correctly. See below for an example of how this could be done as
+part of a docker-compose file:
+
+```
+optimize:
+    container_name: optimize
+    image: camunda/optimize:latest
+    ports:
+        - 8090:8090
+    environment:
+        - SPRING_PROFILES_ACTIVE=ccsm
+        - CAMUNDA_OPTIMIZE_IAM_ISSUER_URL=http://localhost:9090
+        - CAMUNDA_OPTIMIZE_IAM_CLIENTID=optimize
+        - CAMUNDA_OPTIMIZE_IAM_CLIENTSECRET=secret
+        - OPTIMIZE_ELASTICSEARCH_HOST=localhost
+        - OPTIMIZE_ELASTICSEARCH_HTTP_PORT=9200
+        - CAMUNDA_OPTIMIZE_SECURITY_AUTH_COOKIE_SAME_SITE_ENABLED=false
+        - CAMUNDA_OPTIMIZE_ENTERPRISE=false
+        - CAMUNDA_OPTIMIZE_ZEEBE_ENABLED=true
+        - CAMUNDA_OPTIMIZE_ZEEBE_NAME=zeebe-record
+        - CAMUNDA_OPTIMIZE_ZEEBE_PARTITION_COUNT=1
+        - CAMUNDA_OPTIMIZE_SHARING_ENABLED=false
+        - CAMUNDA_OPTIMIZE_UI_LOGOUT_HIDDEN=true
+```
+
+Some configuration properties are optional and have default values. See below for a description of each property:
+
+Name | Description | Default value
+-----|-------------|--------------
+SPRING_PROFILES_ACTIVE | Starts Optimize in Self-Managed mode | 
+CAMUNDA_OPTIMIZE_IAM_ISSUER_URL| The URL at which IAM can be accessed by Optimize | 
+CAMUNDA_OPTIMIZE_IAM_CLIENTID | The Client ID used to register Optimize with IAM | 
+CAMUNDA_OPTIMIZE_IAM_CLIENTSECRET | The secret used when registering Optimize with IAM | 
+OPTIMIZE_ELASTICSEARCH_HOST | The address/hostname under which the Elasticsearch node is available. | localhost
+OPTIMIZE_ELASTICSEARCH_HTTP_PORT | The port number used by Elasticsearch to accept HTTP connections | 9200
+CAMUNDA_OPTIMIZE_SECURITY_AUTH_COOKIE_SAME_SITE_ENABLED| Determines whether or not `same-site` is enabled for Optimize Cookies. Must be set to false | true
+CAMUNDA_OPTIMIZE_ENTERPRISE | This should only be set to true if an Enterprise License has been acquired | true
+CAMUNDA_OPTIMIZE_ZEEBE_ENABLED | Enables import of Zeebe data in Optimize | false
+CAMUNDA_OPTIMIZE_ZEEBE_NAME | The record prefix for exported Zeebe records | zeebe-record
+CAMUNDA_OPTIMIZE_ZEEBE_PARTITION_COUNT | The number of partitions configured in Zeebe | 1
+CAMUNDA_OPTIMIZE_SHARING_ENABLED | Disables the sharing feature (this is not currently supported) | false
+CAMUNDA_OPTIMIZE_UI_LOGOUT_HIDDEN | Disables the logout button (logout is handled by IAM instead) | 1
+
+## Requirements
+
+Self-Managed Optimize must be able to connect to Elasticsearch in order to write/read data. In addition, Optimize needs 
+to connect to IAM for authentication purposes. Both of these requirements can be configured with the options described above.
+
+Optimize must also be configured as a client in IAM, and users will only be granted access to Optimize if they have a role
+that has `write:*` permission for Optimize.
+
+For Optimize to import Zeebe data, Optimize must also be configured to be aware of the record prefix used when the 
+records are exported to Elasticsearch. This can also be configured as per the above example.

--- a/docs/self-managed/optimize-deployment/setup.md
+++ b/docs/self-managed/optimize-deployment/setup.md
@@ -6,9 +6,13 @@ description: "Install and configure Optimize Self-Managed."
 
 ## Install using Docker
 
-The `camunda/optimize:latest` docker image can be used to run Optimize in Self-Managed as a container. Certain environment
+The `camunda/optimize:latest` Docker image can be used to run Optimize in Self-Managed as a container. Certain environment
 variables need to be set for this to work correctly. See below for an example of how this could be done as
-part of a docker-compose file:
+part of a `docker-compose` file:
+
+[//]:# (What do you mean when you say "Certain environment
+variables need to be set for this to work correctly." I would maybe add something like "Certain environment
+variables must be set for this to work correctly. In this document, we'll step through these necessary adjustments. First, see an example of these adjustments in the sample below using a `docker-compose` file:)
 
 ```
 optimize:
@@ -32,31 +36,31 @@ optimize:
         - CAMUNDA_OPTIMIZE_UI_LOGOUT_HIDDEN=true
 ```
 
-Some configuration properties are optional and have default values. See below for a description of each property:
+Some configuration properties are optional and have default values. See a description of these properties and their default values in the table below:
 
 Name | Description | Default value
 -----|-------------|--------------
-SPRING_PROFILES_ACTIVE | Starts Optimize in Self-Managed mode | 
-CAMUNDA_OPTIMIZE_IAM_ISSUER_URL| The URL at which IAM can be accessed by Optimize | 
-CAMUNDA_OPTIMIZE_IAM_CLIENTID | The Client ID used to register Optimize with IAM | 
-CAMUNDA_OPTIMIZE_IAM_CLIENTSECRET | The secret used when registering Optimize with IAM | 
+SPRING_PROFILES_ACTIVE | Starts Optimize in Self-Managed mode. | 
+CAMUNDA_OPTIMIZE_IAM_ISSUER_URL| The URL at which IAM can be accessed by Optimize. | 
+CAMUNDA_OPTIMIZE_IAM_CLIENTID | The Client ID used to register Optimize with IAM. | 
+CAMUNDA_OPTIMIZE_IAM_CLIENTSECRET | The secret used when registering Optimize with IAM. | 
 OPTIMIZE_ELASTICSEARCH_HOST | The address/hostname under which the Elasticsearch node is available. | localhost
-OPTIMIZE_ELASTICSEARCH_HTTP_PORT | The port number used by Elasticsearch to accept HTTP connections | 9200
-CAMUNDA_OPTIMIZE_SECURITY_AUTH_COOKIE_SAME_SITE_ENABLED| Determines whether or not `same-site` is enabled for Optimize Cookies. Must be set to false | true
-CAMUNDA_OPTIMIZE_ENTERPRISE | This should only be set to true if an Enterprise License has been acquired | true
-CAMUNDA_OPTIMIZE_ZEEBE_ENABLED | Enables import of Zeebe data in Optimize | false
-CAMUNDA_OPTIMIZE_ZEEBE_NAME | The record prefix for exported Zeebe records | zeebe-record
-CAMUNDA_OPTIMIZE_ZEEBE_PARTITION_COUNT | The number of partitions configured in Zeebe | 1
-CAMUNDA_OPTIMIZE_SHARING_ENABLED | Disables the sharing feature (this is not currently supported) | false
-CAMUNDA_OPTIMIZE_UI_LOGOUT_HIDDEN | Disables the logout button (logout is handled by IAM instead) | 1
+OPTIMIZE_ELASTICSEARCH_HTTP_PORT | The port number used by Elasticsearch to accept HTTP connections. | 9200
+CAMUNDA_OPTIMIZE_SECURITY_AUTH_COOKIE_SAME_SITE_ENABLED| Determines whether or not `same-site` is enabled for Optimize Cookies. This must be set to `false`. | true
+CAMUNDA_OPTIMIZE_ENTERPRISE | This should only be set to `true` if an Enterprise License has been acquired | true
+CAMUNDA_OPTIMIZE_ZEEBE_ENABLED | Enables import of Zeebe data in Optimize. | false
+CAMUNDA_OPTIMIZE_ZEEBE_NAME | The record prefix for exported Zeebe records. | zeebe-record
+CAMUNDA_OPTIMIZE_ZEEBE_PARTITION_COUNT | The number of partitions configured in Zeebe. | 1
+CAMUNDA_OPTIMIZE_SHARING_ENABLED | Disables the sharing feature (this is not currently supported). | false
+CAMUNDA_OPTIMIZE_UI_LOGOUT_HIDDEN | Disables the logout button (logout is handled by IAM). | 1
 
 ## Requirements
 
-Self-Managed Optimize must be able to connect to Elasticsearch in order to write/read data. In addition, Optimize needs 
+Self-Managed Optimize must be able to connect to Elasticsearch to write and read data. In addition, Optimize needs 
 to connect to IAM for authentication purposes. Both of these requirements can be configured with the options described above.
 
 Optimize must also be configured as a client in IAM, and users will only be granted access to Optimize if they have a role
 that has `write:*` permission for Optimize.
 
 For Optimize to import Zeebe data, Optimize must also be configured to be aware of the record prefix used when the 
-records are exported to Elasticsearch. This can also be configured as per the above example.
+records are exported to Elasticsearch. This can also be configured per the example above.

--- a/sidebars.js
+++ b/sidebars.js
@@ -412,6 +412,7 @@ module.exports = {
         "self-managed/optimize-deployment/setup/common-problems",
           ],
         },
+        "self-managed/optimize-deployment/setup",
         {
           Plugins: [
         "self-managed/optimize-deployment/plugins/plugin-system",


### PR DESCRIPTION
relates to OPT-5827

Configuration page for Optimize CCSM. Please do not merge, we still need to test this as part of a complete docker-compose file with all other components, and also confirm that no config is missing here.

It's also not clear where documentation should live for shared components such as IAM/Zeebe/Elasticsearch. Open to suggestions for how to make this clearer and/or more complete