### PR TITLE
Update available expressions overview in expressions concept

### DIFF
--- a/docs/components/concepts/expressions.md
+++ b/docs/components/concepts/expressions.md
@@ -17,6 +17,7 @@ Additionally, the following attributes of BPMN elements can define an expression
 - Timer catch event: [timer definition](/components/modeler/bpmn/timer-events/timer-events.md#timers)
 - Message catch event/receive task: [message name](/components/modeler/bpmn/message-events/message-events.md#messages)
 - Service task/business rule task/script task/send task: [job type](/components/modeler/bpmn/service-tasks/service-tasks.md#task-definition), [job retries](/components/modeler/bpmn/service-tasks/service-tasks.md#task-definition)
+- User task: [assignee](/components/modeler/bpmn/user-tasks/user-tasks.md#assignments), [candidateGroups](/components/modeler/bpmn/user-tasks/user-tasks.md#assignments)
 - Call activity: [process id](/components/modeler/bpmn/call-activities/call-activities.md#defining-the-called-process)
 
 ## Expressions vs. static values

--- a/docs/components/concepts/expressions.md
+++ b/docs/components/concepts/expressions.md
@@ -16,7 +16,7 @@ Additionally, the following attributes of BPMN elements can define an expression
 
 - Timer catch event: [timer definition](/components/modeler/bpmn/timer-events/timer-events.md#timers)
 - Message catch event/receive task: [message name](/components/modeler/bpmn/message-events/message-events.md#messages)
-- Service task: [job type](/components/modeler/bpmn/service-tasks/service-tasks.md#task-definition), [job retries](/components/modeler/bpmn/service-tasks/service-tasks.md#task-definition)
+- Service task/business rule task/script task/send task: [job type](/components/modeler/bpmn/service-tasks/service-tasks.md#task-definition), [job retries](/components/modeler/bpmn/service-tasks/service-tasks.md#task-definition)
 - Call activity: [process id](/components/modeler/bpmn/call-activities/call-activities.md#defining-the-called-process)
 
 ## Expressions vs. static values

--- a/versioned_docs/version-1.1/components/concepts/expressions.md
+++ b/versioned_docs/version-1.1/components/concepts/expressions.md
@@ -16,7 +16,7 @@ Additionally, the following attributes of BPMN elements can define an expression
 
 - Timer catch event: [timer definition](/reference/bpmn-processes/timer-events/timer-events.md#timers)
 - Message catch event/receive task: [message name](/reference/bpmn-processes/message-events/message-events.md#messages)
-- Service task: [job type](/reference/bpmn-processes/service-tasks/service-tasks.md#task-definition), [job retries](/reference/bpmn-processes/service-tasks/service-tasks.md#task-definition)
+- Service task/business rule task/script task/send task: [job type](/reference/bpmn-processes/service-tasks/service-tasks.md#task-definition), [job retries](/reference/bpmn-processes/service-tasks/service-tasks.md#task-definition)
 - Call activity: [process id](/reference/bpmn-processes/call-activities/call-activities.md#defining-the-called-process)
 
 ## Expressions vs. static values

--- a/versioned_docs/version-1.2/components/concepts/expressions.md
+++ b/versioned_docs/version-1.2/components/concepts/expressions.md
@@ -16,7 +16,7 @@ Additionally, the following attributes of BPMN elements can define an expression
 
 - Timer catch event: [timer definition](/reference/bpmn-processes/timer-events/timer-events.md#timers)
 - Message catch event/receive task: [message name](/reference/bpmn-processes/message-events/message-events.md#messages)
-- Service task: [job type](/reference/bpmn-processes/service-tasks/service-tasks.md#task-definition), [job retries](/reference/bpmn-processes/service-tasks/service-tasks.md#task-definition)
+- Service task/business rule task/script task/send task: [job type](/reference/bpmn-processes/service-tasks/service-tasks.md#task-definition), [job retries](/reference/bpmn-processes/service-tasks/service-tasks.md#task-definition)
 - Call activity: [process id](/reference/bpmn-processes/call-activities/call-activities.md#defining-the-called-process)
 
 ## Expressions vs. static values


### PR DESCRIPTION
This updates the available expressions overview in the expressions concept to align with what is available in each version.

Since 1.1, some new tasks are supports that sue the `job type` and `retries` like service task: business rule task, script task and send task. This documentation change has been made for both the current docs as well as the versioned docs from 1.1 onwards.

Since 1.3 (latest), user tasks now support assignments which can be specified using 2 attributes: `assignee` and `candidateGroups`. Both can be specified as static value and as expression. 

closes #566 