### PR TITLE
Add update warning about faulty 1.3.0 and 1.3.1 versions

### DIFF
--- a/docs/guides/update-guide/120-to-130.md
+++ b/docs/guides/update-guide/120-to-130.md
@@ -1,22 +1,20 @@
 ---
 id: 120-to-130
 title: Update 1.2 to 1.3
-description: "Review which adjustments must be made to migrate from Camunda Cloud 1.2.x to 1.3.0."
+description: "Review which adjustments must be made to migrate from Camunda Cloud 1.2.x to 1.3.2."
 ---
 <span class="badge badge--primary">Intermediate</span>
 
-The following sections explain which adjustments must be made to migrate from Camunda Cloud 1.2.x to 1.3.0 for each component of the system.
+The following sections explain which adjustments must be made to migrate from Camunda Cloud 1.2.x to 1.3.2 for each component of the system.
 
 ## Server
 
 ### Zeebe
 
 :::caution
-The docker image for Zeebe 1.3.0 does not set a system locale.
-This can lead to user data corruption, in particular with non-ascii characters (such as umlauts) in process variables.
+A critical [issue](https://github.com/camunda-cloud/zeebe/issues/8611) which may lead to data loss was identified in 1.3.0 and 1.3.1. This issue is related to the new assignee and candidate group feature introduced in 1.3.0, and only affects users which make use of it. However, when updating, it's still recommended that you skip versions 1.3.0 and 1.3.1 and update directly from 1.2.9 to 1.3.2.
 
-Please refer to the [release notes](https://github.com/camunda-cloud/zeebe/releases/tag/1.3.0) for mitigations and announcements
-of patch releases.
+Please refer to the [release notes](https://github.com/camunda-cloud/zeebe/releases/tag/1.3.2) for more.
 :::
 
 ### Operate


### PR DESCRIPTION
This PR edits the update from 1.2.0 to 1.3.0 guide to add a warning to skip version 1.3.0 and 1.3.1 due to this [critical issue](https://github.com/camunda-cloud/zeebe/issues/8611).

Ideally, we should push and release this as soon as possible so users are aware of this notice as soon as possible.