### PR TITLE
docs(contact): direct bugs and feature requests to community

### DIFF
--- a/src/pages/contact.md
+++ b/src/pages/contact.md
@@ -9,9 +9,7 @@ There are various channels where you can reach us.
 
 - We encourage everyone to participate in our **community** via the [Camunda Cloud community forum](https://forum.camunda.io/) or [Slack](https://camunda-cloud.slack.com/), where you can exchange ideas with other Zeebe and Camunda Cloud users, as well as the product developers. If you are joining our Slack for the first time, you will need to get an [invite](https://zeebe-slack-invite.herokuapp.com/) first.
 
-- If you find a **bug**, open an issue in this [repository](https://github.com/camunda-cloud/issues). The bugs have a default template, so please describe what doesn't work in detail.
-
-- We also accept **feature requests** through a similar process. Please open an issue in this [repository](https://github.com/camunda-cloud/issues). The feature requests have a default template, so describe what you'd like to see in detail.
+- We welcome your **bug** reports and **feature requests** through our community channels mentioned above.
 
 - For **security-related issues**, review our [Security notices](../../docs/reference/notices) for the most up-to-date information on known issues and steps to report a vulnerability so we can solve the problem as quickly as possible. Do not use GitHub for security-related issues.
 


### PR DESCRIPTION
https://github.com/camunda-cloud/issues/issues is internal and no longer accessible for community members (customers and users) to use. We will now direct bugs and feature requests to Slack and the forums.