### PR TITLE
Removing deprecated references

### DIFF
--- a/docs/guides/message-correlation.md
+++ b/docs/guides/message-correlation.md
@@ -63,7 +63,7 @@ To run the demonstration, take the following steps:
   npm i && npm i -g ts-node typescript
   ```
 
-3. In another terminal, start the Zeebe Broker using the `simple-monitor` profile from the [zeebe-docker-compose](https://github.com/camunda-community-hub/zeebe-docker-compose) repo.
+3. In another terminal, start the Zeebe Broker in addition to  [simple-monitor](https://github.com/camunda-community-hub/zeebe-simple-monitor).
 
 4. Deploy the workflow and start an instance:
 

--- a/docs/self-managed/zeebe-deployment/docker/install.md
+++ b/docs/self-managed/zeebe-deployment/docker/install.md
@@ -22,8 +22,6 @@ A default docker compose configuration to run Zeebe, Operate and Tasklist is ava
 
 Download this file to your local computer, `cd` into that directory and run `docker-compose up`. 
 
-Some more information on Zeebe using `docker-compose`, including more specific configurations, are available in the [zeebe-docker-compose](https://github.com/zeebe-io/zeebe-docker-compose/blob/master/README.md) community extension.
-
 #### Exposed ports
 
 - `26500`: Zeebe Gateway API


### PR DESCRIPTION
Removing references to zeebe-docker-compose because it is depricated