### PR TITLE
Fix typo

### DIFF
--- a/docs/reference/feel/language-guide/feel-expression.md
+++ b/docs/reference/feel/language-guide/feel-expression.md
@@ -303,7 +303,7 @@ The nested values of a specific key can be extracted by `.key`.
 // ["foo", "bar"]
 ```
 
-### Evaluate an enary test
+### Evaluate a unary test
 
 Evaluates a [unary-tests expression](../feel-unary-tests) with the given value.
 


### PR DESCRIPTION
I think this meant to say 'unary test'