### PR TITLE
Unified the variable-mapping description

### DIFF
--- a/docs/components/modeler/bpmn/business-rule-tasks/business-rule-tasks.md
+++ b/docs/components/modeler/bpmn/business-rule-tasks/business-rule-tasks.md
@@ -31,9 +31,9 @@ specifies the type of job workers should subscribe to (e.g. DMN).
 Use [task headers](/components/modeler/bpmn/service-tasks/service-tasks.md#task-headers) to pass static parameters to the job
 worker (e.g. the key of the decision to evaluate).
 
-Define [variable mappings](/components/concepts/variables.md#inputoutput-variable-mappings) to transform the
-variables passed to the job worker, or to customize how the variables of the job are merged
-in the process instance.
+Define [variable mappings](/components/concepts/variables.md#inputoutput-variable-mappings)
+the [same way as a service task does](/components/modeler/bpmn/service-tasks/service-tasks.md#variable-mappings)
+to transform the variables passed to the job worker, or to customize how the variables of the job merge.
 
 ## Additional resources
 

--- a/docs/components/modeler/bpmn/message-events/message-events.md
+++ b/docs/components/modeler/bpmn/message-events/message-events.md
@@ -73,9 +73,9 @@ To correlate a message to the message event, the message is published with the d
 
 ## Variable mappings
 
-Define [variable mappings](/components/concepts/variables.md#inputoutput-variable-mappings)
-the [same way as a service task does](/components/modeler/bpmn/service-tasks/service-tasks.md#variable-mappings)
-to transform the variables passed to the job worker, or to customize how the variables of the job merge.
+By default, all message variables are merged into the process instance. This behavior can be customized by defining an output mapping at the message catch event.
+
+Visit the documentation regarding [variable mappings](/components/modeler/bpmn/service-tasks/service-tasks.md#variable-mappings) for more information on this topic.
 
 ## Additional resources
 

--- a/docs/components/modeler/bpmn/message-events/message-events.md
+++ b/docs/components/modeler/bpmn/message-events/message-events.md
@@ -73,9 +73,9 @@ To correlate a message to the message event, the message is published with the d
 
 ## Variable mappings
 
-By default, all message variables are merged into the process instance. This behavior can be customized by defining an output mapping at the message catch event.
-
-Visit the documentation regarding [variable mappings](/components/modeler/bpmn/service-tasks/service-tasks.md#variable-mappings) for more information on this topic.
+Define [variable mappings](/components/concepts/variables.md#inputoutput-variable-mappings)
+the [same way as a service task does](/components/modeler/bpmn/service-tasks/service-tasks.md#variable-mappings)
+to transform the variables passed to the job worker, or to customize how the variables of the job merge.
 
 ## Additional resources
 

--- a/docs/components/modeler/bpmn/receive-tasks/receive-tasks.md
+++ b/docs/components/modeler/bpmn/receive-tasks/receive-tasks.md
@@ -28,11 +28,10 @@ To correlate a message to the receive task, the message is published with the de
 
 ## Variable mappings
 
-Output variable mappings are used to customize how variables are merged into the process instance.
-These can contain multiple elements that specify which variables should be mapped.
-The `Process Variable Name` of an output denotes the variable name outside of the activity.
+Define [variable mappings](/components/concepts/variables.md#inputoutput-variable-mappings)
+the [same way as a service task does](/components/modeler/bpmn/service-tasks/service-tasks.md#variable-mappings)
+to transform the variables passed to the job worker, or to customize how the variables of the job merge.
 
-Visit our documentation on [input and output variable mappings](/components/concepts/variables.md#inputoutput-variable-mappings) for more information on this topic.
 ## Additional resources
 
 ### XML representation

--- a/docs/components/modeler/bpmn/receive-tasks/receive-tasks.md
+++ b/docs/components/modeler/bpmn/receive-tasks/receive-tasks.md
@@ -28,9 +28,9 @@ To correlate a message to the receive task, the message is published with the de
 
 ## Variable mappings
 
-Define [variable mappings](/components/concepts/variables.md#inputoutput-variable-mappings)
-the [same way as a service task does](/components/modeler/bpmn/service-tasks/service-tasks.md#variable-mappings)
-to transform the variables passed to the job worker, or to customize how the variables of the job merge.
+Output variable mappings are used to customize how variables are merged into the process instance.
+These can contain multiple elements that specify which variables should be mapped.
+The `Process Variable Name` of an output denotes the variable name outside the activity.
 
 ## Additional resources
 

--- a/docs/components/modeler/bpmn/receive-tasks/receive-tasks.md
+++ b/docs/components/modeler/bpmn/receive-tasks/receive-tasks.md
@@ -32,6 +32,8 @@ Output variable mappings are used to customize how variables are merged into the
 These can contain multiple elements that specify which variables should be mapped.
 The `Process Variable Name` of an output denotes the variable name outside the activity.
 
+Visit our documentation on [input and output variable mappings](/components/concepts/variables.md#inputoutput-variable-mappings) for more information on this topic.
+
 ## Additional resources
 
 ### XML representation

--- a/docs/components/modeler/bpmn/script-tasks/script-tasks.md
+++ b/docs/components/modeler/bpmn/script-tasks/script-tasks.md
@@ -31,9 +31,9 @@ the type of job workers should subscribe to (e.g. `script`).
 Use [task headers](/components/modeler/bpmn/service-tasks/service-tasks.md#task-headers) to pass static parameters to the job
 worker (e.g. the script to evaluate). The community extension [Zeebe Script Worker](https://github.com/camunda-community-hub/zeebe-script-worker) requires certain attributes to be set in the task headers.
 
-Define [variable mappings](/components/modeler/bpmn/service-tasks/service-tasks.md#variable-mappings) to transform the
-variables passed to the job worker, or to customize how the variables of the job merge
-in the process instance.
+Define [variable mappings](/components/concepts/variables.md#inputoutput-variable-mappings)
+the [same way as a service task does](/components/modeler/bpmn/service-tasks/service-tasks.md#variable-mappings)
+to transform the variables passed to the job worker, or to customize how the variables of the job merge.
 
 ## Additional resources
 

--- a/docs/components/modeler/bpmn/send-tasks/send-tasks.md
+++ b/docs/components/modeler/bpmn/send-tasks/send-tasks.md
@@ -33,8 +33,9 @@ way as a service task does. It specifies the type of job that workers should sub
 Use [task headers](/components/modeler/bpmn/service-tasks/service-tasks.md#task-headers) to pass static parameters to the job
 worker (e.g. the name of the topic to publish the message to).
 
-Define [variable mappings](/components/modeler/bpmn/service-tasks/service-tasks.md#variable-mappings) to transform the
-variables passed to the job worker, or to customize how the variables of the job merge in the process instance.
+Define [variable mappings](/components/concepts/variables.md#inputoutput-variable-mappings)
+the [same way as a service task does](/components/modeler/bpmn/service-tasks/service-tasks.md#variable-mappings)
+to transform the variables passed to the job worker, or to customize how the variables of the job merge.
 
 ## Additional resources
 


### PR DESCRIPTION
Originates of: https://github.com/camunda-cloud/camunda-cloud-documentation/issues/610

I think it quite a good step to unify all the description for task-types which behave like service-tasks. 
Unified variable-mapping descriptions:
- business-rule-task
- script-tasks
- send-tasks

@korthout please let me know if I am missing a task type. 👍 