### PR TITLE
Document business rule task with called decision

### DIFF
--- a/docs/components/concepts/incidents.md
+++ b/docs/components/concepts/incidents.md
@@ -11,6 +11,7 @@ Incidents are created in different situations, including the following:
 - A job is failed and it has no retries left.
 - An input or output variable mapping can't be applied.
 - A condition can't be evaluated.
+- A decision can't be evaluated.
 
 :::note
 Incidents are not created when an unexpected exception (e.g. `NullPointerException`, `OutOfMemoyError` etc.) occurs.

--- a/docs/components/modeler/bpmn/business-rule-tasks/business-rule-tasks.md
+++ b/docs/components/modeler/bpmn/business-rule-tasks/business-rule-tasks.md
@@ -46,7 +46,7 @@ All variables in scope of the business rule task are available to the decision e
 decision is evaluated. Input mappings can be used to transform the variables into a format accepted
 by the decision.
 
-:::note
+:::info
 Input mappings are applied on activating the business rule task (or when an incident at the business
 rule task is resolved), before the decision evaluation. When an incident is resolved at the business
 rule task, then the input mappings are applied again before evaluating the decision. This can affect
@@ -70,11 +70,6 @@ When a process instance enters a business rule task with alternative task implem
 a corresponding job and waits for its completion. A job worker should request jobs of this job type
 and process them. When the job is completed, the process instance continues.
 
-:::note
-Jobs for business rule tasks are not processed by Zeebe itself. To process them, you must provide a
-job worker.
-:::
-
 A business rule task must define a [job
 type](/components/modeler/bpmn/service-tasks/service-tasks.md#task-definition) the same way as a
 service task does. This specifies the type of job that workers should subscribe to (e.g.
@@ -86,14 +81,6 @@ worker (e.g. the key of the decision to evaluate).
 Define [variable mappings](/components/concepts/variables.md#inputoutput-variable-mappings)
 the [same way as a service task does](/components/modeler/bpmn/service-tasks/service-tasks.md#variable-mappings)
 to transform the variables passed to the job worker, or to customize how the variables of the job merge.
-
-:::tip Community Extension
-
-Take a look at the [Zeebe DMN Worker](https://github.com/camunda-community-hub/zeebe-dmn-worker).
-This is a community extension providing a job worker to evaluate DMN decisions. You can run it, or
-use it as a blueprint for your own job worker.
-
-:::
 
 ## Additional resources
 

--- a/docs/components/modeler/bpmn/business-rule-tasks/business-rule-tasks.md
+++ b/docs/components/modeler/bpmn/business-rule-tasks/business-rule-tasks.md
@@ -11,8 +11,9 @@ modeled in [Decision Model and Notation](https://www.omg.org/dmn/) (DMN).
 
 :::info
 Camunda Platform 8 supports alternative task implementations for the business rule task. If you want
-to use your own implementation for a business rule task, see the **Job worker implementation**
-section below. The sections before it apply to the DMN decision implementation only.
+to use your own implementation for a business rule task, see the [Job worker
+implementation](#job-worker-implementation) section below. The sections before it apply to the DMN
+decision implementation only.
 :::
 
 When the process instance arrives at a business rule task, a decision is evaluated using the

--- a/docs/components/modeler/bpmn/business-rule-tasks/business-rule-tasks.md
+++ b/docs/components/modeler/bpmn/business-rule-tasks/business-rule-tasks.md
@@ -75,8 +75,10 @@ Jobs for business rule tasks are not processed by Zeebe itself. To process them,
 job worker.
 :::
 
-A business rule task must define a [job type](/components/modeler/bpmn/service-tasks/service-tasks.md#task-definition) the same way as a service task does. This
-specifies the type of job that workers should subscribe to (e.g. DMN).
+A business rule task must define a [job
+type](/components/modeler/bpmn/service-tasks/service-tasks.md#task-definition) the same way as a
+service task does. This specifies the type of job that workers should subscribe to (e.g.
+`calculate_risk`).
 
 Use [task headers](/components/modeler/bpmn/service-tasks/service-tasks.md#task-headers) to pass static parameters to the job
 worker (e.g. the key of the decision to evaluate).
@@ -112,7 +114,7 @@ A business rule task with a job worker implementation and a custom header:
 ```xml
 <bpmn:businessRuleTask id="calculate-risk" name="Calculate risk">
   <bpmn:extensionElements>
-    <zeebe:taskDefinition type="DMN" />
+    <zeebe:taskDefinition type="calculate_risk" />
     <zeebe:taskHeaders>
       <zeebe:header key="decisionRef" value="risk" />
     </zeebe:taskHeaders>

--- a/docs/components/modeler/bpmn/business-rule-tasks/business-rule-tasks.md
+++ b/docs/components/modeler/bpmn/business-rule-tasks/business-rule-tasks.md
@@ -9,24 +9,74 @@ modeled in [Decision Model and Notation](https://www.omg.org/dmn/) (DMN).
 
 ![task](assets/business-rule-task.png)
 
-Business rule tasks behave exactly like [service tasks](/components/modeler/bpmn/service-tasks/service-tasks.md). Both
-task types are based on jobs and [job workers](/components/concepts/job-workers.md).
-
-The differences between these task types are the visual representation (i.e. the task marker) and
-the semantics for the model.
-
-When a process instance enters a business rule task, it creates a corresponding job and waits for
-its completion. A job worker should request jobs of this job type and process them. When the job is
-completed, the process instance continues.
-
 :::note
-Jobs for business rule tasks are not processed by Zeebe itself. To process them, you must provide a job worker.
+Camunda Cloud supports alternative task implementations for the business rule task. If you want to
+use your own implementation for a business rule task, see the **Alternative task implementation**
+section below. The sections before it apply to the DMN decision implementation only.
 :::
 
-## Defining a task
+When the process execution arrives at a business rule task, a decision is evaluated using the
+internal DMN decision engine. Once the decision is made, the process instance continues.
+
+If the decision evaluation is unsuccessful, an [incident](/components/concepts/incidents.md) is
+raised at the business rule task. When the incident is resolved, the decision is evaluated again.
+
+## Defining a called decision
+
+A called decision links the business rule task to a DMN decision. It can be defined using the
+`zeebe:calledDecision` extension element.
+
+A business rule task must define the DMN decision id of the called decision as `decisionId`.
+Usually, the `decisionId` is defined as a static value (e.g. `shipping_box_size`), but it can also
+be defined as an [expression](/components/concepts/expressions.md) (e.g. `= "shipping_box_size_" +
+countryCode`). The expression is evaluated on activating the business rule task (or when an incident
+at the business rule task is resolved), after input mappings have been applied. The expression must
+result in a `string`.
+
+A business rule task must define the process variable name of the decision result as
+`resultVariable`. The result of the decision will be stored in this variable. The `resultVariable`
+is defined as a static value.
+
+## Variable mappings
+
+By default, the variable defined by `resultVariable` is merged into the process instance. This
+behavior can be customized by defining an output mapping at the business rule task.
+
+All variables in scope of the business rule task are available to the decision engine when the
+decision is evaluated. Input mappings can be used to transform the variables into a format accepted
+by the decision.
+
+:::note
+Input mappings are applied on activating the business rule task (or when an incident at the business
+rule task is resolved), before the decision evaluation. When an incident is resolved at the business
+rule task, then the input mappings are applied again before evaluating the decision. This can affect
+the result of the decision.
+:::
+
+For more information about this topic visit the documentation about [Input/output variable
+mappings](/components/concepts/variables.md#inputoutput-variable-mappings).
+
+## Alternative task implementation
+A business rule task does not have to evaluate a decision modeled with DMN. Instead, you can also
+use [job workers](/components/concepts/job-workers.md) to implement your business rule task.
+
+An alternative task implementation can be defined using the `zeebe:taskDefinition` extension element.
+
+Business rule tasks with an alternative task implementation behave exactly like [service
+tasks](/components/modeler/bpmn/service-tasks/service-tasks.md). The differences between these task
+types are the visual representation (i.e. the task marker) and the semantics for the model.
+
+When a process instance enters a business rule task with alternative task implementation, it creates
+a corresponding job and waits for its completion. A job worker should request jobs of this job type
+and process them. When the job is completed, the process instance continues.
+
+:::note
+Jobs for business rule tasks are not processed by Zeebe itself. To process them, you must provide a
+job worker.
+:::
 
 A business rule task must define a [job type](/components/modeler/bpmn/service-tasks/service-tasks.md#task-definition) the same way as a service task does. This
-specifies the type of job workers should subscribe to (e.g. DMN).
+specifies the type of job that workers should subscribe to (e.g. DMN).
 
 Use [task headers](/components/modeler/bpmn/service-tasks/service-tasks.md#task-headers) to pass static parameters to the job
 worker (e.g. the key of the decision to evaluate).
@@ -34,8 +84,6 @@ worker (e.g. the key of the decision to evaluate).
 Define [variable mappings](/components/concepts/variables.md#inputoutput-variable-mappings)
 the [same way as a service task does](/components/modeler/bpmn/service-tasks/service-tasks.md#variable-mappings)
 to transform the variables passed to the job worker, or to customize how the variables of the job merge.
-
-## Additional resources
 
 :::tip Community Extension
 
@@ -45,9 +93,21 @@ use it as a blueprint for your own job worker.
 
 :::
 
+## Additional resources
+
 ### XML representation
 
-A business rule task with a custom header:
+A business rule task with a called decision:
+
+```xml
+<bpmn:businessRuleTask id="determine-box-size" name="Determine shipping box size">
+  <bpmn:extensionElements>
+    <zeebe:calledDecision decisionId="shipping_box_size" resultVariable="boxSize" />
+  </bpmn:extensionElements>
+</bpmn:businessRuleTask>
+```
+
+A business rule task with an alternative task implementation and a custom header:
 
 ```xml
 <bpmn:businessRuleTask id="calculate-risk" name="Calculate risk">
@@ -62,5 +122,6 @@ A business rule task with a custom header:
 
 ### References
 
+- [DMN decision](/components/modeler/dmn/dmn.md)
 - [Job handling](/components/concepts/job-workers.md)
 - [Variable mappings](/components/concepts/variables.md#inputoutput-variable-mappings)

--- a/docs/components/modeler/bpmn/business-rule-tasks/business-rule-tasks.md
+++ b/docs/components/modeler/bpmn/business-rule-tasks/business-rule-tasks.md
@@ -11,7 +11,7 @@ modeled in [Decision Model and Notation](https://www.omg.org/dmn/) (DMN).
 
 :::info
 Camunda Platform 8 supports alternative task implementations for the business rule task. If you want
-to use your own implementation for a business rule task, see the **Alternative task implementation**
+to use your own implementation for a business rule task, see the **Job worker implementation**
 section below. The sections before it apply to the DMN decision implementation only.
 :::
 
@@ -56,13 +56,13 @@ the result of the decision.
 For more information about this topic visit the documentation about [Input/output variable
 mappings](/components/concepts/variables.md#inputoutput-variable-mappings).
 
-## Alternative task implementation
+## Job worker implementation
 A business rule task does not have to evaluate a decision modeled with DMN. Instead, you can also
 use [job workers](/components/concepts/job-workers.md) to implement your business rule task.
 
-An alternative task implementation can be defined using the `zeebe:taskDefinition` extension element.
+A job worker implementation can be defined using the `zeebe:taskDefinition` extension element.
 
-Business rule tasks with an alternative task implementation behave exactly like [service
+Business rule tasks with a job worker implementation behave exactly like [service
 tasks](/components/modeler/bpmn/service-tasks/service-tasks.md). The differences between these task
 types are the visual representation (i.e. the task marker) and the semantics for the model.
 
@@ -107,7 +107,7 @@ A business rule task with a called decision:
 </bpmn:businessRuleTask>
 ```
 
-A business rule task with an alternative task implementation and a custom header:
+A business rule task with a job worker implementation and a custom header:
 
 ```xml
 <bpmn:businessRuleTask id="calculate-risk" name="Calculate risk">

--- a/docs/components/modeler/bpmn/business-rule-tasks/business-rule-tasks.md
+++ b/docs/components/modeler/bpmn/business-rule-tasks/business-rule-tasks.md
@@ -15,7 +15,7 @@ to use your own implementation for a business rule task, see the **Job worker im
 section below. The sections before it apply to the DMN decision implementation only.
 :::
 
-When the process execution arrives at a business rule task, a decision is evaluated using the
+When the process instance arrives at a business rule task, a decision is evaluated using the
 internal DMN decision engine. Once the decision is made, the process instance continues.
 
 If the decision evaluation is unsuccessful, an [incident](/components/concepts/incidents.md) is

--- a/docs/components/modeler/bpmn/business-rule-tasks/business-rule-tasks.md
+++ b/docs/components/modeler/bpmn/business-rule-tasks/business-rule-tasks.md
@@ -11,8 +11,8 @@ modeled in [Decision Model and Notation](https://www.omg.org/dmn/) (DMN).
 
 :::info
 Camunda Platform 8 supports alternative task implementations for the business rule task. If you want
-to use your own implementation for a business rule task, see the [Job worker
-implementation](#job-worker-implementation) section below. The sections before it apply to the DMN
+to use your own implementation for a business rule task, see the [job worker
+implementation](#job-worker-implementation) section below. The sections before this job worker implementation apply to the DMN
 decision implementation only.
 :::
 
@@ -31,11 +31,11 @@ A business rule task must define the DMN decision id of the called decision as `
 Usually, the `decisionId` is defined as a static value (e.g. `shipping_box_size`), but it can also
 be defined as an [expression](/components/concepts/expressions.md) (e.g. `= "shipping_box_size_" +
 countryCode`). The expression is evaluated on activating the business rule task (or when an incident
-at the business rule task is resolved), after input mappings have been applied. The expression must
+at the business rule task is resolved) after input mappings have been applied. The expression must
 result in a `string`.
 
 A business rule task must define the process variable name of the decision result as
-`resultVariable`. The result of the decision will be stored in this variable. The `resultVariable`
+`resultVariable`. The result of the decision is stored in this variable. The `resultVariable`
 is defined as a static value.
 
 ## Variable mappings
@@ -50,14 +50,15 @@ by the decision.
 :::info
 Input mappings are applied on activating the business rule task (or when an incident at the business
 rule task is resolved), before the decision evaluation. When an incident is resolved at the business
-rule task, then the input mappings are applied again before evaluating the decision. This can affect
+rule task, the input mappings are applied again before evaluating the decision. This can affect
 the result of the decision.
 :::
 
-For more information about this topic visit the documentation about [Input/output variable
+For more information about this topic, visit the documentation about [input/output variable
 mappings](/components/concepts/variables.md#inputoutput-variable-mappings).
 
 ## Job worker implementation
+
 A business rule task does not have to evaluate a decision modeled with DMN. Instead, you can also
 use [job workers](/components/concepts/job-workers.md) to implement your business rule task.
 

--- a/docs/components/modeler/bpmn/business-rule-tasks/business-rule-tasks.md
+++ b/docs/components/modeler/bpmn/business-rule-tasks/business-rule-tasks.md
@@ -9,9 +9,9 @@ modeled in [Decision Model and Notation](https://www.omg.org/dmn/) (DMN).
 
 ![task](assets/business-rule-task.png)
 
-:::note
-Camunda Cloud supports alternative task implementations for the business rule task. If you want to
-use your own implementation for a business rule task, see the **Alternative task implementation**
+:::info
+Camunda Platform 8 supports alternative task implementations for the business rule task. If you want
+to use your own implementation for a business rule task, see the **Alternative task implementation**
 section below. The sections before it apply to the DMN decision implementation only.
 :::
 

--- a/docs/components/modeler/bpmn/manual-tasks/manual-tasks.md
+++ b/docs/components/modeler/bpmn/manual-tasks/manual-tasks.md
@@ -8,7 +8,7 @@ A manual task defines a task that is external to the BPM engine. This is used to
 by somebody who the engine does not need to know of and there is no known system or UI interface.
 
 For the engine, a manual task is handled as a pass-through activity, automatically continuing the 
-process at the moment the process execution arrives.
+process at the moment the process instance arrives.
 
 ![task](assets/manual-task.png)
 

--- a/docs/components/modeler/bpmn/user-tasks/user-tasks.md
+++ b/docs/components/modeler/bpmn/user-tasks/user-tasks.md
@@ -5,7 +5,7 @@ description: "A user task is used to model work that needs to be done by a human
 ---
 
 A user task is used to model work that needs to be done by a human actor. When
-the process execution arrives at such a user task, a new job similar to a
+the process instance arrives at such a user task, a new job similar to a
 [service task](/components/modeler/bpmn/service-tasks/service-tasks.md) is created. The process instance
 stops at this point and waits until the job is completed.
 


### PR DESCRIPTION
Camunda Cloud 1.4 will add support for business rule tasks with a called decision extension element. This PR adds the related documentation on how to define such a business rule task and what its behavior is within the process execution, as well as how it links the business rule task to a DMN decision.

It also clearly separates the main implementation (calling a DMN decision) and the possibility to provide alternative implementations (using a job worker).

closes #421