### PR TITLE
Document new DeployResource RPC and its usage

### DIFF
--- a/docs/apis-clients/cli-client/get-started.md
+++ b/docs/apis-clients/cli-client/get-started.md
@@ -96,7 +96,7 @@ Use the following conditional expression for the **else** sequence flow:
 Now, you can deploy the [process](./assets/gettingstarted_quickstart_advanced.bpmn). Navigate to the folder where you saved your process.
 
 ```bash
-zbctl deploy gettingstarted_quickstart_advanced.bpmn
+zbctl deploy resource gettingstarted_quickstart_advanced.bpmn
 ```
 
 If the deployment is successful, you'll get the following output:
@@ -104,12 +104,14 @@ If the deployment is successful, you'll get the following output:
 ```bash
 {
   "key": 2251799813685493,
-  "processes": [
+  "deployments": [
     {
-      "bpmnProcessId": "camunda-cloud-quick-start-advanced",
-      "version": 1,
-      "processKey": 2251799813685492,
-      "resourceName": "gettingstarted_quickstart_advanced.bpmn"
+      "process": {
+        "bpmnProcessId": "camunda-cloud-quick-start-advanced",
+        "version": 1,
+        "processKey": 2251799813685492,
+        "resourceName": "gettingstarted_quickstart_advanced.bpmn"
+      }
     }
   ]
 }

--- a/docs/apis-clients/cli-client/index.md
+++ b/docs/apis-clients/cli-client/index.md
@@ -54,7 +54,7 @@ Available Commands:
   cancel      Cancel resource
   complete    Complete a resource
   create      Create resources
-  deploy      Creates new process defined by provided BPMN file as processPath
+  deploy      Deploys new resources for each file provided
   fail        Fail a resource
   generate    Generate documentation
   help        Help about any command

--- a/docs/apis-clients/go-client/get-started.md
+++ b/docs/apis-clients/go-client/get-started.md
@@ -135,7 +135,7 @@ The broker stores the process under its BPMN process id and assigns a version.
 ```go
 	// After the client is created
 	ctx := context.Background()
-	response, err := client.NewDeployProcessCommand().AddResourceFile("order-process.bpmn").Send(ctx)
+	response, err := client.NewDeployResourceCommand().AddResourceFile("order-process.bpmn").Send(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -253,7 +253,7 @@ func main() {
 
 	// deploy process
 	ctx := context.Background()
-	response, err := zbClient.NewDeployProcessCommand().AddResourceFile("order-process-4.bpmn").Send(ctx)
+	response, err := zbClient.NewDeployResourceCommand().AddResourceFile("order-process-4.bpmn").Send(ctx)
 	if err != nil {
 		panic(err)
 	}

--- a/docs/apis-clients/go-client/get-started.md
+++ b/docs/apis-clients/go-client/get-started.md
@@ -35,7 +35,7 @@ module github.com/zb-user/zb-example
 
 go 1.17
 
-require github.com/camunda-cloud/zeebe/clients/go v1.2.9
+require github.com/camunda/zeebe/clients/go/v8 v8.0.0
 ```
 
 3. Set the connection settings and client credentials as environment variables:
@@ -59,8 +59,8 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/camunda-cloud/zeebe/clients/go/pkg/zbc"
-	"github.com/camunda-cloud/zeebe/clients/go/pkg/pb"
+	"github.com/camunda/zeebe/clients/go/v8/pkg/zbc"
+	"github.com/camunda/zeebe/clients/go/v8/pkg/pb"
 	"os"
 )
 
@@ -147,7 +147,7 @@ Run the program and verify the process deployed successfully.
 You should see a similar output:
 
 ```
-key:2251799813686743 processes:<bpmnProcessId:"order-process" version:3 processKey:2251799813686742 resourceName:"order-process.bpmn" >
+key:2251799813685254  processes:{bpmnProcessId:"order-process"  version:3  processDefinitionKey:2251799813685253  resourceName:"order-process.bpmn"}
 ```
 
 ## Create a process instance
@@ -222,9 +222,9 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/camunda-cloud/zeebe/clients/go/pkg/entities"
-	"github.com/camunda-cloud/zeebe/clients/go/pkg/worker"
-	"github.com/camunda-cloud/zeebe/clients/go/pkg/zbc"
+	"github.com/camunda/zeebe/clients/go/v8/pkg/entities"
+	"github.com/camunda/zeebe/clients/go/v8/pkg/worker"
+	"github.com/camunda/zeebe/clients/go/v8/pkg/zbc"
 	"log"
 	"os"
 )
@@ -345,13 +345,12 @@ When observing the Zeebe Monitor, you can see the process instance moved from th
 When you run the example above, you should see a similar output to the following:
 
 ```
-key:2251799813686751 processes:<bpmnProcessId:"order-process" version:4 processKey:2251799813686750 resourceName:"order-process.bpmn" >
-processKey:2251799813686750 bpmnProcessId:"order-process" version:4 processInstanceKey:22517998136
-86752
-2019/06/06 20:59:50 Complete job 2251799813686760 of type payment-service
-2019/06/06 20:59:50 Processing order: 31243
-2019/06/06 20:59:50 Collect money using payment method: VISA
-2019/06/06 20:59:50 Successfully completed job
+key:2251799813685256  deployments:{process:{bpmnProcessId:"order-process-4"  version:1  processDefinitionKey:2251799813685255  resourceName:"order-process.bpmn"}}
+processDefinitionKey:2251799813685255  bpmnProcessId:"order-process-4"  version:1  processInstanceKey:2251799813685257
+2022/04/06 16:20:59 Complete job 2251799813685264 of type payment-service
+2022/04/06 16:20:59 Processing order: 31243
+2022/04/06 16:20:59 Collect money using payment method: VISA
+2022/04/06 16:20:59 Successfully completed job
 ```
 
 ## What's next?

--- a/docs/apis-clients/go-client/index.md
+++ b/docs/apis-clients/go-client/index.md
@@ -14,7 +14,7 @@ module github.com/zb-user/zb-example
 
 go 1.17
 
-require github.com/camunda-cloud/zeebe/clients/go v1.2.9
+require github.com/camunda/zeebe/clients/go/v8 v8.0.0
 ```
 
 ## Bootstrapping
@@ -27,7 +27,7 @@ package main
 import (
     "context"
     "fmt"
-    "github.com/camunda-cloud/zeebe/clients/go/pkg/zbc"
+    "github.com/camunda/zeebe/clients/go/v8/pkg/zbc"
 )
 
 func main() {
@@ -86,7 +86,7 @@ package main
 import (
     "context"
     "fmt"
-    "github.com/camunda-cloud/zeebe/clients/go/pkg/zbc"
+    "github.com/camunda/zeebe/clients/go/v8/pkg/zbc"
     "os"
 )
 

--- a/docs/apis-clients/grpc.md
+++ b/docs/apis-clients/grpc.md
@@ -272,76 +272,6 @@ Returned if:
 - The given variables argument is not a valid JSON document; it is expected to be a valid
   JSON document where the root node is an object.
 
-### `DeployProcess` RPC
-
-Deploys one or more processes to Zeebe. Note that this is an atomic call,
-i.e. either all processes are deployed, or none of them are.
-
-#### Input: `DeployProcessRequest`
-
-```protobuf
-message DeployProcessRequest {
-  // List of process resources to deploy
-  repeated ProcessRequestObject processes = 1;
-}
-
-message ProcessRequestObject {
-  enum ResourceType {
-    // FILE type means the gateway will try to detect the resource type
-    // using the file extension of the name field
-    FILE = 0;
-    BPMN = 1; // extension 'bpmn'
-    YAML = 2 [deprecated = true]; // extension 'yaml'; removed as of release 1.0
-  }
-
-  // the resource basename, e.g. myProcess.bpmn
-  string name = 1;
-  // the resource type; if set to BPMN or YAML then the file extension
-  // is ignored
-  // As of release 1.0, YAML support was removed and BPMN is the only supported resource type.
-  // The field was kept to not break clients.
-  ResourceType type = 2 [deprecated = true];
-  // the process definition as a UTF8-encoded string
-  bytes definition = 3;
-}
-```
-
-#### Output: `DeployProcessResponse`
-
-```protobuf
-message DeployProcessResponse {
-  // the unique key identifying the deployment
-  int64 key = 1;
-  // a list of deployed processes
-  repeated ProcessMetadata processes = 2;
-}
-
-message ProcessMetadata {
-  // the bpmn process ID, as parsed during deployment; together with the version forms a
-  // unique identifier for a specific process definition
-  string bpmnProcessId = 1;
-  // the assigned process version
-  int32 version = 2;
-  // the assigned key, which acts as a unique identifier for this process
-  int64 processKey = 3;
-  // the resource name (see: ProcessRequestObject.name) from which this process was
-  // parsed
-  string resourceName = 4;
-}
-```
-
-#### Errors
-
-##### GRPC_STATUS_INVALID_ARGUMENT
-
-Returned if:
-
-- No resources given.
-- At least one resource is invalid. A resource is considered invalid if:
-  - It is not a BPMN or YAML file (currently detected through the file extension).
-  - The resource data is not deserializable (e.g. detected as BPMN, but it's broken XML).
-  - The process is invalid (e.g. an event-based gateway has an outgoing sequence flow to a task.)
-
 ### `DeployResource` RPC
 
 Deploys one or more resources (e.g. processes or decision models) to Zeebe.
@@ -750,6 +680,84 @@ Returned if:
 Returned if:
 
 - Retries is not greater than 0.
+
+## Deprecated RPCs
+
+The following RPCs are exposed by the gateway service, but have been deprecated.
+
+### `DeployProcess` RPC
+
+:::note
+Deprecated since 8, replaced by [DeployResource RPC](#deployresource-rpc).
+:::
+
+Deploys one or more processes to Zeebe. Note that this is an atomic call,
+i.e. either all processes are deployed, or none of them are.
+
+#### Input: `DeployProcessRequest`
+
+```protobuf
+message DeployProcessRequest {
+  // List of process resources to deploy
+  repeated ProcessRequestObject processes = 1;
+}
+
+message ProcessRequestObject {
+  enum ResourceType {
+    // FILE type means the gateway will try to detect the resource type
+    // using the file extension of the name field
+    FILE = 0;
+    BPMN = 1; // extension 'bpmn'
+    YAML = 2 [deprecated = true]; // extension 'yaml'; removed as of release 1.0
+  }
+
+  // the resource basename, e.g. myProcess.bpmn
+  string name = 1;
+  // the resource type; if set to BPMN or YAML then the file extension
+  // is ignored
+  // As of release 1.0, YAML support was removed and BPMN is the only supported resource type.
+  // The field was kept to not break clients.
+  ResourceType type = 2 [deprecated = true];
+  // the process definition as a UTF8-encoded string
+  bytes definition = 3;
+}
+```
+
+#### Output: `DeployProcessResponse`
+
+```protobuf
+message DeployProcessResponse {
+  // the unique key identifying the deployment
+  int64 key = 1;
+  // a list of deployed processes
+  repeated ProcessMetadata processes = 2;
+}
+
+message ProcessMetadata {
+  // the bpmn process ID, as parsed during deployment; together with the version forms a
+  // unique identifier for a specific process definition
+  string bpmnProcessId = 1;
+  // the assigned process version
+  int32 version = 2;
+  // the assigned key, which acts as a unique identifier for this process
+  int64 processKey = 3;
+  // the resource name (see: ProcessRequestObject.name) from which this process was
+  // parsed
+  string resourceName = 4;
+}
+```
+
+#### Errors
+
+##### GRPC_STATUS_INVALID_ARGUMENT
+
+Returned if:
+
+- No resources given.
+- At least one resource is invalid. A resource is considered invalid if:
+  - It is not a BPMN or YAML file (currently detected through the file extension).
+  - The resource data is not deserializable (e.g. detected as BPMN, but it's broken XML).
+  - The process is invalid (e.g. an event-based gateway has an outgoing sequence flow to a task.)
 
 ## Technical error handling
 

--- a/docs/apis-clients/grpc.md
+++ b/docs/apis-clients/grpc.md
@@ -6,10 +6,6 @@ description: "Zeebe clients use gRPC to communicate with the cluster."
 
 [Zeebe](../components/zeebe/zeebe-overview.md) clients use [gRPC](https://grpc.io/) to communicate with the cluster.
 
-:::note
-This specification still contains references to YAML workflows. This is a [deprecated feature](./reference/announcements.md) and will eventually be removed.
-:::
-
 ## Gateway service
 
 The Zeebe client gRPC API is exposed through a single gateway service.

--- a/docs/apis-clients/java-client-examples/process-deploy.md
+++ b/docs/apis-clients/java-client-examples/process-deploy.md
@@ -19,7 +19,7 @@ Run the Zeebe broker with endpoint `localhost:26500` (default).
 
 ```java
 final DeploymentEvent deploymentEvent =
-        client.newDeployCommand()
+        client.newDeployResourceCommand()
             .addResourceFromClasspath("demoProcess.bpmn")
             .send()
             .join();

--- a/docs/apis-clients/java-client/zeebe-process-test.md
+++ b/docs/apis-clients/java-client/zeebe-process-test.md
@@ -105,7 +105,7 @@ Start an assertion using the following entry points:
 ### Deployment assertions
 
 ```java
-DeploymentEvent event = client.newDeployCommand()
+DeploymentEvent event = client.newDeployResourceCommand()
   .addResourceFromClasspath("my-process.bpmn")
   .send()
   .join();

--- a/docs/guides/utilizing-forms.md
+++ b/docs/guides/utilizing-forms.md
@@ -83,7 +83,7 @@ Copy the JSON schema, and go back to the BPMN diagram you modeled earlier. Selec
 With Camunda Platform 7, deploy your diagram to Zeebe and create an instance using the following command:
 
 ```sh
-zbctl deploy /path/to/my/diagram.bpmn
+zbctl deploy resource /path/to/my/diagram.bpmn
 zbctl create instance diagram-id
 ```
 

--- a/docs/reference/announcements.md
+++ b/docs/reference/announcements.md
@@ -39,3 +39,8 @@ The support for YAML processes was removed as of release 1.0. The `resourceType`
 ## Deprecated in 1.3
 
 The `zeebe-test` module was deprecated in 1.3.0. We are currently planning to remove `zeebe-test` for the 1.4.0 release.
+
+## Deprecated in 8.0
+
+The [DeployProcess RPC](/apis-clients/grpc.md#deployprocess-rpc) was deprecated in 8.0. 
+It is replaced by the [DeployResource RPC](/apis-clients/grpc.md#deployresource-rpc).

--- a/docs/reference/announcements.md
+++ b/docs/reference/announcements.md
@@ -4,14 +4,6 @@ title: "Announcements"
 description: "Important announcements including deprecation & removal notices"
 ---
 
-The support for YAML processes was removed as of release 1.0. The `resourceType` in Deployment record and Process grpc request are deprecated, they will always contain `BPMN` as value.
-
-### YAML workflows descriptions
-
-YAML workflows are an alternative way to specify simple workflows using a proprietary YAML description. This feature is deprecated and no longer advertised in the documentation. YAML workflows gained little traction with users and we do not intend to support them in the future.
-
-We recommend all users of YAML workflows to migrate to BPMN workflows as soon as possible. The feature will eventually be removed completely, though the date when this will occur has yet to be defined.
-
 ## Deprecated in 0.23.0-alpha2
 
 - TOML configuration - deprecated and removed in 0.23.0-alpha2
@@ -31,6 +23,14 @@ In terms of specifying values, there were two minor changes:
 
 - Memory sizes are now specified like this: `512MB` (old way: `512M`)
 - Durations (e.g. timeouts) can now also be given in ISO-8601 Durations format. However, you can still use the established method and specify a timeout of `30s`
+
+## Deprecated in 0.26.0
+
+### YAML workflows descriptions
+
+YAML workflows are an alternative way to specify simple workflows using a proprietary YAML description. This feature is deprecated and no longer advertised in the documentation. YAML workflows gained little traction with users and we do not intend to support them in the future.
+
+We recommend all users of YAML workflows to migrate to BPMN workflows as soon as possible. The feature will eventually be removed completely, though the date when this will occur has yet to be defined.
 
 ## Removed in 1.0
 


### PR DESCRIPTION
This PR:
- documents the new DeployResource RPC
- deprecates the existing DeployProcess RPC
- updates all zbctl, Go-client and Java-client usage in the docs to their respective new uses of this RPC.

closes #707 
closes #708 