### PR TITLE
chore(desktopModeler): polish basic tutorial texts (#685)

### DIFF
--- a/docs/components/modeler/desktop-modeler/connect-to-camunda-cloud.md
+++ b/docs/components/modeler/desktop-modeler/connect-to-camunda-cloud.md
@@ -4,31 +4,22 @@ title: Connect to Camunda Cloud
 description: "Camunda Modeler can communicate directly with Camunda Cloud."
 ---
 
-Desktop Modeler can communicate directly with Camunda Cloud.
+Desktop Modeler can directly deploy diagrams and start process instances in Camunda Cloud. Follow the steps below to deploy a diagram:
 
-Click the deployment icon:
+1. Click the deployment icon:
 
 ![deployment icon](./img/deploy-icon.png)
 
-There are two options to select a target:
-
-- A self-hosted solution
-- Configure Camunda Cloud
+2. Click **Camunda Cloud SaaS**, or alternatively, select **Camunda Cloud Self-Managed** if you want to deploy to a [local installation](../../../../self-managed/zeebe-deployment/local/install/), for example:
 
 ![deployment configuration](./img/deploy-diagram-camunda-cloud.png)
 
-To connect and deploy a diagram to Camunda Cloud, follow the steps below:
-
-:::note
-The BPMN diagram must not only be valid, but also understood by the Zeebe engine. For example, if you model a service task but do not configure the element, you will get an error message during deployment.
-:::
-
-1. Select **Camunda Cloud**.
-2. For the communication, you need the `Cluster Id` of your cluster and the credentials (`Client Id`, `Client Secret`) of your [API client](../../cloud-console/manage-clusters/manage-api-clients.md).
+3. Input the `Cluster URL` and the credentials (`Client ID`, `Client Secret`) of your [API client](../../cloud-console/manage-clusters/manage-api-clients.md):
 
 ![deployment via camunda cloud](./img/deploy-diagram-camunda-cloud-remember.png)
 
-3. Select the **Remember** checkbox if you want your connection data to be persisted.
-4. Click **Deploy** to perform the actual deployment.
+4. Select the **Remember** checkbox if you want to locally store the connection information.
+
+5. Click **Deploy** to perform the actual deployment.
 
 ![deployment successful](./img/deploy-diagram-camunda-cloud-success.png)

--- a/docs/components/modeler/desktop-modeler/model-your-first-diagram.md
+++ b/docs/components/modeler/desktop-modeler/model-your-first-diagram.md
@@ -13,9 +13,7 @@ After [downloading](./install-the-modeler.md) and starting Desktop Modeler, you 
 
 ![new diagram](./img/new-diagram.png)
 
-As with [Web Modeler](../web-modeler/model-your-first-diagram.md), you can now add new elements.
-
-3. On the left side of the screen you will find the element palette supported by the engine. Drag and drop the elements onto the diagram:
+3. On the left side of the screen you will find the element palette. Drag and drop the elements onto the diagram:
 
 ![elements](./img/elements.png)
 
@@ -23,8 +21,8 @@ Elements that support different types can be reconfigured by clicking on the cor
 
 ![task configuration](img/element-configuration.png)
 
-4. Each element has adjustable attributes. Use the properties panel on the right side of the page:
+4. Use the properties panel on the right side of the page to edit the properties of the currently selected element:
 
 ![properties panel](img/properties-panel.png)
 
-5. Once you finish modeling and configuring your diagram, save it as BPMN or deploy it on a [Camunda Cloud cluster](./connect-to-camunda-cloud.md). You can also export the diagram as an image.
+5. Once you finish modeling and configuring your diagram, you can deploy it to a [Camunda Cloud cluster](./connect-to-camunda-cloud.md).

--- a/docs/components/modeler/desktop-modeler/start-instance.md
+++ b/docs/components/modeler/desktop-modeler/start-instance.md
@@ -1,17 +1,13 @@
 ---
 id: start-instance
 title: Start a new process instance
-description: "Once you establish your connection to Camunda Cloud, you can start a new instance of your BPMN diagram."
+description: "After you have deployed your process to Camunda Cloud, you can start a new instance of this process via the play icon."
 ---
 
-Once you establish your [connection to Camunda Cloud](./connect-to-camunda-cloud.md), you can start a new instance of your BPMN diagram via the play icon:
+After you have [deployed your process to Camunda Cloud](./connect-to-camunda-cloud.md), you can start a new instance of this process via the play icon:
 
 ![start instance icon](./img/start-instance-icon.png)
 
-:::note
-The BPMN diagram must be deployed on your cluster before starting a new instance.
-:::
-
-If an instance is started successfully, a corresponding message is displayed:
+After the instance was started successfully, a corresponding message is displayed:
 
 ![start instance successful](./img/start-instance-successful.png)


### PR DESCRIPTION
* This brings the `release-1.4.0` and `master` branch back in sync for the DesktopModeler

* This updates and clarifies the basic tutorial texts
* No content changes, just polishing and corrections