### PR TITLE
chore(desktopModeler): change title of deploy diagram page

### DIFF
--- a/docs/components/modeler/desktop-modeler/connect-to-camunda-cloud.md
+++ b/docs/components/modeler/desktop-modeler/connect-to-camunda-cloud.md
@@ -1,7 +1,6 @@
 ---
 id: connect-to-camunda-cloud
-title: Connect to Camunda Platform 8
-description: "Camunda Modeler can communicate directly with Camunda Platform 8."
+title: Deploy your first diagram
 ---
 
 Desktop Modeler can directly deploy diagrams and start process instances in Camunda Platform 8. Follow the steps below to deploy a diagram:


### PR DESCRIPTION
* This makes the desktop modeler guide easier to read. 
* `Connect to Camunda Platform 8` is rather unspecific (what does connect mean?). Actually this page is about deploying after all and nothing else