### PR TITLE
docs(operate): renaming

### DIFF
--- a/docs/components/operate/index.md
+++ b/docs/components/operate/index.md
@@ -26,8 +26,8 @@ In addition to providing visibility into active and completed process instances,
 
 Learn how to use Operate to monitor process instances and more features in the [Operate user guide](/components/operate/userguide/basic-operate-navigation.md).
 
-Operate is also available for production use (with support) in the Camunda Cloud offering.
+Operate is also available for production use (with support) in the Camunda Platform 8 offering.
 
-To try out Operate in Camunda Cloud, sign up [here](https://accounts.cloud.camunda.io/signup).
+To try out Operate in Camunda Platform 8, sign up [here](https://accounts.cloud.camunda.io/signup).
 
 Because Operate can be a helpful tool when getting started with Zeebe and building an initial proof of concept, we make it available under the [Operate trial license](https://camunda.com/legal/terms/cloud-terms-and-conditions/general-terms-and-conditions-for-the-operate-trial-version/). There are no restrictions under this license when it comes to the length of the evaluation period or the available feature set _as long as you use Operate in non-production environments only._


### PR DESCRIPTION
Renaming Camunda Cloud to Camunda Platform 8. Smaller PR than I was expecting! 