### PR TITLE
docs(apis-clients): renaming

### DIFF
--- a/docs/apis-clients/cli-client/get-started.md
+++ b/docs/apis-clients/cli-client/get-started.md
@@ -4,11 +4,11 @@ title: "CLI client - Getting started guide"
 sidebar_label: "Getting started guide"
 ---
 
-In this tutorial, you will learn to use the CLI client `zbctl` to interact with Camunda Cloud.
+In this tutorial, you will learn to use the CLI client `zbctl` to interact with Camunda Platform 8.
 
 ## Prerequisites
 
-- [Camunda Cloud account](/guides/getting-started/create-camunda-cloud-account.md)
+- [Camunda Platform 8 account](/guides/getting-started/create-camunda-cloud-account.md)
 - [Cluster](/guides/getting-started/create-camunda-cloud-account.md)
 - [Client credentials](/guides/getting-started/setup-client-connection-credentials.md)
 - [Modeler](/guides/getting-started/model-your-first-process.md)
@@ -37,7 +37,7 @@ export ZEEBE_CLIENT_SECRET='[Client Secret]'
 export ZEEBE_AUTHORIZATION_SERVER_URL='[OAuth API]'
 ```
 
-When creating client credentials in Camunda Cloud, you have the option to download a file with the lines above filled out for you.
+When creating client credentials in Camunda Platform 8, you have the option to download a file with the lines above filled out for you.
 
 Alternatively, use the [described flags](https://www.npmjs.com/package/zbctl#usage) (`--address`, `--clientId`, and `--clientSecret`) with the `zbctl` commands.
 

--- a/docs/apis-clients/cli-client/index.md
+++ b/docs/apis-clients/cli-client/index.md
@@ -4,7 +4,7 @@ title: CLI client
 sidebar_label: "Quick reference"
 ---
 
-`zbctl` is the command line interface to interact with Camunda Cloud. After installation, a connection can be tested immediately.
+`zbctl` is the command line interface to interact with Camunda Platform 8. After installation, a connection can be tested immediately.
 
 ## Installation
 
@@ -27,7 +27,7 @@ export ZEEBE_CLIENT_SECRET='[Client Secret]'
 export ZEEBE_AUTHORIZATION_SERVER_URL='[OAuth API]'
 ```
 
-When you create client credentials in Camunda Cloud, you have the option to download a file with the lines above filled out for you.
+When you create client credentials in Camunda Platform 8, you have the option to download a file with the lines above filled out for you.
 
 Alternatively, use the [described flags](https://www.npmjs.com/package/zbctl#usage) (`--address`, `--clientId`, and `--clientSecret`) with the `zbctl` commands.
 

--- a/docs/apis-clients/cloud-console-api-reference.md
+++ b/docs/apis-clients/cloud-console-api-reference.md
@@ -1,14 +1,14 @@
 ---
 id: cloud-console-api-reference
 title: Cloud Console API clients (REST)
-description: "To interact with Camunda Cloud programmatically without using the Camunda Cloud UI, create Cloud API clients."
+description: "To interact with Camunda Platform 8 programmatically without using the Camunda Platform 8 UI, create Cloud API clients."
 ---
 
 ## Cloud API management
 
-To interact with Camunda Cloud programmatically without using the Camunda Cloud UI, create Cloud API clients in the organization settings under the **Cloud Management API** tab.
+To interact with Camunda Platform 8 programmatically without using the Camunda Platform 8 UI, create Cloud API clients in the organization settings under the **Cloud Management API** tab.
 
-Cloud API clients are created for an organization, and therefore can access all Camunda Cloud clusters of this organization.
+Cloud API clients are created for an organization, and therefore can access all Camunda Platform 8 clusters of this organization.
 
 A client can have one or multiple of the following permissions:
 

--- a/docs/apis-clients/go-client/get-started.md
+++ b/docs/apis-clients/go-client/get-started.md
@@ -4,13 +4,13 @@ title: "Go client - Getting started guide"
 sidebar_label: "Getting started guide"
 ---
 
-In this tutorial, you will learn how to use the Go client in a Go application to interact with Camunda Cloud.
+In this tutorial, you will learn how to use the Go client in a Go application to interact with Camunda Platform 8.
 
 You can find the complete source code on [GitHub](https://github.com/zeebe-io/zeebe-get-started-go-client).
 
 ## Prerequisites
 
-- [Camunda Cloud account](/guides/getting-started/create-camunda-cloud-account.md)
+- [Camunda Platform 8 account](/guides/getting-started/create-camunda-cloud-account.md)
 - [Cluster](/guides/getting-started/create-camunda-cloud-account.md)
 - [Client credentials](/guides/getting-started/setup-client-connection-credentials.md)
 - [Modeler](/guides/getting-started/model-your-first-process.md)
@@ -48,7 +48,7 @@ export ZEEBE_AUTHORIZATION_SERVER_URL='[OAuth API]'
 ```
 
 :::note
-When you create client credentials in Camunda Cloud, you have the option to download a file with the lines above filled out for you.
+When you create client credentials in Camunda Platform 8, you have the option to download a file with the lines above filled out for you.
 :::
 
 4. Create a `main.go` file inside the module and add the following lines to bootstrap the Zeebe client:
@@ -186,7 +186,7 @@ processKey:2251799813686742 bpmnProcessId:"order-process" version:3 processInsta
 
 Want to see how the process instance is executed? Follow the steps below:
 
-1. Go to the cluster in Camunda Cloud and select it.
+1. Go to the cluster in Camunda Platform 8 and select it.
 1. Click on the link to [Operate](/components/operate/userguide/basic-operate-navigation.md).
 1. Select the process **order process**.
 

--- a/docs/apis-clients/go-client/index.md
+++ b/docs/apis-clients/go-client/index.md
@@ -76,7 +76,7 @@ export ZEEBE_CLIENT_SECRET='[Client Secret]'
 export ZEEBE_AUTHORIZATION_SERVER_URL='[OAuth API]'
 ```
 
-When you create client credentials in Camunda Cloud, you have the option to download a file with the lines above filled out for you.
+When you create client credentials in Camunda Platform 8, you have the option to download a file with the lines above filled out for you.
 
 Given these environment variables, you can instantiate the client as follows:
 

--- a/docs/apis-clients/java-client/index.md
+++ b/docs/apis-clients/java-client/index.md
@@ -76,7 +76,7 @@ export ZEEBE_CLIENT_SECRET='[Client Secret]'
 export ZEEBE_AUTHORIZATION_SERVER_URL='[OAuth API]'
 ```
 
-When you create client credentials in Camunda Cloud, you have the option to download a file with the lines above filled out for you.
+When you create client credentials in Camunda Platform 8, you have the option to download a file with the lines above filled out for you.
 
 Given these environment variables, you can instantiate the client as follows:
 

--- a/docs/apis-clients/java-client/zeebe-process-test.md
+++ b/docs/apis-clients/java-client/zeebe-process-test.md
@@ -3,7 +3,7 @@ id: zeebe-process-test
 title: "Zeebe Process Test"
 ---
 
-[Zeebe Process Test](https://github.com/camunda-cloud/zeebe-process-test) allows you to unit test your Camunda Cloud BPMN
+[Zeebe Process Test](https://github.com/camunda-cloud/zeebe-process-test) allows you to unit test your Camunda Platform 8 BPMN
 processes. It will start a Zeebe test engine and provide you with a set of assertions you can use to verify your process 
 behaves as expected.
 

--- a/docs/apis-clients/overview.md
+++ b/docs/apis-clients/overview.md
@@ -2,21 +2,21 @@
 id: overview
 title: "Working with APIs & Clients"
 sidebar_label: "Overview"
-description: "Programmatically work with Camunda Cloud through APIs & clients"
+description: "Programmatically work with Camunda Platform 8 through APIs & clients"
 ---
 
 This section steps through a variety of offered APIs and clients for integration.
 
 ## APIs and interacting with other components
 
-The clients mentioned below interact with Zeebe, the workflow engine integrated into Camunda Cloud.
+The clients mentioned below interact with Zeebe, the workflow engine integrated into Camunda Platform 8.
 
-Other components in Camunda Cloud, such as [Tasklist API (GraphQL)](/apis-clients/tasklist-api/generated.md), provide language-agnostic APIs, but no clients to interact with them. GraphQL enables you to query, claim, and complete user tasks.
+Other components in Camunda Platform 8, such as [Tasklist API (GraphQL)](/apis-clients/tasklist-api/generated.md), provide language-agnostic APIs, but no clients to interact with them. GraphQL enables you to query, claim, and complete user tasks.
 
 ### Additional APIs
 
-- [Public API](public-api.md) - Camunda Cloud's provided public API.
-- [Cloud Console API clients (REST)](cloud-console-api-reference.md) - Enables you to programmatically create and manage clusters, and interact with Camunda Cloud programmatically without using the Camunda Cloud UI.
+- [Public API](public-api.md) - Camunda Platform 8's provided public API.
+- [Cloud Console API clients (REST)](cloud-console-api-reference.md) - Enables you to programmatically create and manage clusters, and interact with Camunda Platform 8 programmatically without using the Camunda Platform 8 UI.
 - [Zeebe API](grpc.md) - Zeebe clients use gRPC to communicate with the cluster.
 
 ## Clients
@@ -29,9 +29,9 @@ Clients allow applications to do the following:
 - Publish messages.
 - Update process instance variables and resolve incidents.
 
-Clients connect to Camunda Cloud via [gRPC](https://grpc.io), a high-performance, open-source, and universal RPC protocol.
+Clients connect to Camunda Platform 8 via [gRPC](https://grpc.io), a high-performance, open-source, and universal RPC protocol.
 
-Camunda Cloud provides several official clients based on this API. Official clients have been developed and tested by Camunda. They also add convenience functions (e.g. thread handling for job workers) on top of the core API.
+Camunda Platform 8 provides several official clients based on this API. Official clients have been developed and tested by Camunda. They also add convenience functions (e.g. thread handling for job workers) on top of the core API.
 
 Community clients supplement the official clients. These clients have not been tested by Camunda.
 

--- a/docs/apis-clients/public-api.md
+++ b/docs/apis-clients/public-api.md
@@ -3,11 +3,11 @@ id: public-api
 title: "Public API"
 ---
 
-Camunda Cloud provides a public API. This section covers the definition of the public API and backwards compatibility for version updates.
+Camunda Platform 8 provides a public API. This section covers the definition of the public API and backwards compatibility for version updates.
 
 ## Backwards compatibility for public API
 
-Camunda Cloud versioning scheme follows the `MAJOR.MINOR.PATCH` pattern put forward by [semantic versioning](https://semver.org/). Camunda Cloud will
+Camunda Platform 8 versioning scheme follows the `MAJOR.MINOR.PATCH` pattern put forward by [semantic versioning](https://semver.org/). Camunda Platform 8 will
 maintain public API backwards compatibility for `MINOR` version updates.
 
 Example: Update from version `1.0.x` to `1.1.y` will not break the public API.


### PR DESCRIPTION
Camunda Cloud to Camunda Platform 8.

I did not include `docs/apis-clients/cli-client/assets/gettingstarted_quickstart_advanced.bpmn` in the renaming, although it looks like the name of the process model could be changed with no issues. 