### PR TITLE
Renaming console c8

### DIFF
--- a/docs/apis-clients/cloud-console-api-reference.md
+++ b/docs/apis-clients/cloud-console-api-reference.md
@@ -1,6 +1,6 @@
 ---
 id: cloud-console-api-reference
-title: Cloud Console API clients (REST)
+title: Console API clients (REST)
 description: "To interact with Camunda Platform 8 programmatically without using the Camunda Platform 8 UI, create Cloud API clients."
 ---
 

--- a/docs/components/cloud-console/introduction.md
+++ b/docs/components/cloud-console/introduction.md
@@ -1,17 +1,17 @@
 ---
 id: introduction
-title: Introduction to Cloud Console
+title: Introduction to Camunda Platform Console
 ---
 
-Cloud Console is the management application for the included products.
+Camunda Platform Console is the management application for the included products.
 
-Using Cloud Console, you can do the folllowing:
+Using Camunda Platform Console, you can do the folllowing:
 
 - [Create](./manage-clusters/create-cluster.md) and [delete](./manage-clusters/delete-cluster.md) clusters.
 - [Manage API clients](./manage-clusters/manage-api-clients.md) to interact with [Zeebe](./components/zeebe/zeebe-overview.md) and [Tasklist](./components/tasklist/introduction.md).
 - [Manage alerts](./manage-clusters/manage-alerts.md) to get notified when workflow errors occur.
 - [Manage IP Whitelists](./manage-clusters/manage-ip-whitelists.md) to restrict access to clusters.
 - [Manage](./manage-organization/organization-settings.md) your organization.
-- [Cloud Console API clients (REST)](./apis-clients/cloud-console-api-reference.md) to manage clusters programmatically.
+- [Console API clients (REST)](./apis-clients/cloud-console-api-reference.md) to manage clusters programmatically.
 
-If you don't have a Camunda Cloud account yet, visit our [Getting Started Guide](../../guides/getting-started/create-camunda-cloud-account.md).
+If you don't have a Camunda Platform 8 account yet, visit our [Getting Started Guide](../../guides/getting-started/create-camunda-cloud-account.md).

--- a/docs/components/cloud-console/manage-clusters/manage-alerts.md
+++ b/docs/components/cloud-console/manage-clusters/manage-alerts.md
@@ -1,10 +1,10 @@
 ---
 id: manage-alerts
 title: Manage alerts
-description: "Camunda Cloud can notify you when process instances stop with an error."
+description: "Camunda Platform 8 can notify you when process instances stop with an error."
 ---
 
-Camunda Cloud can notify you when process instances stop with an error.
+Camunda Platform 8 can notify you when process instances stop with an error.
 
 There are two forms of notification:
 

--- a/docs/components/cloud-console/manage-organization/manage-users.md
+++ b/docs/components/cloud-console/manage-organization/manage-users.md
@@ -6,7 +6,7 @@ description: "Let's take a closer look at the rights and responsibilities of use
 
 ## General rights concept
 
-When a user signs up for Camunda Cloud, they receive a personal organization. Clusters the user creates in this organization are assigned to this organization.
+When a user signs up for Camunda Platform 8, they receive a personal organization. Clusters the user creates in this organization are assigned to this organization.
 
 If several users need access to the same Zeebe cluster, all users can be assigned to the same organization.
 
@@ -20,7 +20,7 @@ To change the owner of the organization, utilize the user administration. The cu
 
 In addition to the owner, the **Admin** role is available as a second role with comprehensive rights. The admin role has the same rights as the owner, with the difference that an admin cannot manage other admins.
 
-The following roles are additionally available, providing dedicated rights for specific elements in Camunda Cloud.
+The following roles are additionally available, providing dedicated rights for specific elements in Camunda Platform 8.
 
 - **Operations Engineer**: Full access to Console and Operate, except cluster deletion privileges
 - **Analyst**: Full access to Optimize and read-only access to clusters
@@ -30,6 +30,6 @@ The following roles are additionally available, providing dedicated rights for s
 
 Users can be assigned multiple roles. For example, a user can have the role of **Operations Engineer** and **Task User**, which gives them access to **Operate** and **Tasklist**.
 
-Users are invited to a Camunda Cloud organization via their email address, which must be accepted by the user. The user remains in the `Pending` state until the invitation is accepted.
+Users are invited to a Camunda Platform 8 organization via their email address, which must be accepted by the user. The user remains in the `Pending` state until the invitation is accepted.
 
-People who do not yet have a Camunda Cloud account can also be invited to an organization. To access the organization, however, the invited individual must first create a Camunda Cloud account by following the instructions in the invitation email.
+People who do not yet have a Camunda Platform 8 account can also be invited to an organization. To access the organization, however, the invited individual must first create a Camunda Platform 8 account by following the instructions in the invitation email.

--- a/docs/components/cloud-console/manage-organization/update-billing-reservations.md
+++ b/docs/components/cloud-console/manage-organization/update-billing-reservations.md
@@ -19,7 +19,7 @@ Once signed up for the **Professional Plan** or **Enterprise Plan**, you have ac
 
 Reservations control how many clusters you can deploy. Increasing the number of reservations allows you to deploy more clusters, while decreasing the number of reservations allows you to deploy fewer clusters.
 
-You can access the **Billing** page by selecting **Organization Management** in the Camunda Cloud Console navigation bar.
+You can access the **Billing** page by selecting **Organization Management** in the Camunda Platform Console navigation bar.
 
 ![billing-overview](./img/billing-overview.png)
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -138,7 +138,7 @@ module.exports = {
           title: "More",
           items: [
             {
-              label: "Camunda Platform 8 Console",
+              label: "Console",
               href: "https://camunda.io",
             },
             {

--- a/sidebars.js
+++ b/sidebars.js
@@ -45,7 +45,7 @@ module.exports = {
         "components/concepts/variables",
         "components/concepts/expressions",
       ],
-      "Cloud Console": [
+      "Console": [
         "components/cloud-console/introduction",
         {
           "Manage your organization": [


### PR DESCRIPTION
- Cloud Console in the sidebar is now just Console
- Cloud Console almost everywhere else is “Camunda Platform Console” (no 8, to match the UI)
- Cloud Console API clients is Console API clients