### PR TITLE
docs(guides): renaming c8

### DIFF
--- a/docs/guides/assets/react-components/create-cluster.md
+++ b/docs/guides/assets/react-components/create-cluster.md
@@ -1,7 +1,7 @@
 ---
 ---
 
-You must create a cluster if you have a new Camunda Cloud account. 
+You must create a cluster if you have a new Camunda Platform 8 account. 
 
 1. To create a cluster, click the **Clusters** tab, and click **Create New Cluster**.
 2. Name your cluster. For the purpose of this guide, we recommend using the **Stable** channel, the latest generation, and the region closest to you. Click **Create**.

--- a/docs/guides/automating-a-process-using-bpmn.md
+++ b/docs/guides/automating-a-process-using-bpmn.md
@@ -23,11 +23,11 @@ BPMN offers control and visibility over your critical business processes. The wo
 ## Set up
 
 Begin by building your BPMN diagrams with [Modeler](../components/modeler/about.md).
-To get started, ensure you’ve [created a Camunda Cloud account](./getting-started/create-camunda-cloud-account.md).
+To get started, ensure you’ve [created a Camunda Platform 8 account](./getting-started/create-camunda-cloud-account.md).
 
 ## Getting started with BPMN
 
-Once logged in to your Camunda Cloud account, take the following steps:
+Once logged in to your Camunda Platform 8 account, take the following steps:
 
 1. Click on the **Modeler** tab at the top of the page.
 2. Open any project from your Web Modeler home view.

--- a/docs/guides/getting-started-orchestrate-human-tasks.md
+++ b/docs/guides/getting-started-orchestrate-human-tasks.md
@@ -6,7 +6,7 @@ description: "Efficiently allocate work through user tasks."
 keywords: [human tasks, orchestration, getting started, user guide]
 ---
 
-Using [Camunda Cloud](./getting-started/create-camunda-cloud-account.md), you can orchestrate human tasks by assigning them to users. Then, users can enter the necessary data to drive the business process.
+Using [Camunda Platform 8](./getting-started/create-camunda-cloud-account.md), you can orchestrate human tasks by assigning them to users. Then, users can enter the necessary data to drive the business process.
 
 When a process instance arrives at such a user task, a new job similar to a service task is created. The process instance stops at this point and waits until the job is completed. Applications like [Tasklist](../components/tasklist/introduction.md) can be used by humans to complete these tasks.
 
@@ -16,7 +16,7 @@ In this guide, we’ll step through one way to create an automated process utili
 
 ### Prerequisites
 
-- Ensure you have a valid [Camunda Cloud account](./getting-started/create-camunda-cloud-account.md), or sign up if you still need one.
+- Ensure you have a valid [Camunda Platform 8 account](./getting-started/create-camunda-cloud-account.md), or sign up if you still need one.
 - (Optional) Install [Camunda Desktop Modeler](../components/modeler/desktop-modeler/install-the-modeler.md).
 
 ### Create a cluster
@@ -31,7 +31,7 @@ To create an automated process with user tasks, take the following steps:
 
 #### Develop your automated process with user tasks
 
-1. Log in to your Camunda Cloud account.
+1. Log in to your Camunda Platform 8 account.
 2. To create a BPMN diagram, navigate to Web Modeler via the **Modeler** tab, and click **New project**.
 3. Name your project and select **New > BPMN Diagram > + Create blank**.
 4. Give your model a descriptive name, and then give your model a descriptive id within the **General** tab inside the properties panel on the right side of the screen. In this case, we've named our model `Preparing dinner` with an id of `preparing-dinner`.
@@ -79,7 +79,7 @@ As mentioned earlier, you'll need to insert the defined variable values into the
 
 Within this example, we've included a form to demonstrate the completion of a human task. To learn more about creating forms within your diagrams, visit our guide on [building forms with Modeler](./utilizing-forms.md).
 
-1. Go back to your Camunda Cloud diagram and select the honeycomb icon and then **View user tasks** to take a look at your user tasks inside Tasklist.
+1. Go back to your Camunda Platform 8 diagram and select the honeycomb icon and then **View user tasks** to take a look at your user tasks inside Tasklist.
 2. Select the open user task on the left panel of **Tasks**. In our example below, this is **Decide what's for dinner**.
 3. Next to **Assignee**, click **Claim** to claim the task.
 4. Once finished entering the appropriate information, click **Complete Task**.

--- a/docs/guides/getting-started-orchestrate-microservices.md
+++ b/docs/guides/getting-started-orchestrate-microservices.md
@@ -50,7 +50,7 @@ Start by designing your automated process using BPMN. This guide introduces you 
 
 To interact with your Camunda Platform 8 cluster, you'll use the Zeebe client. First, you'll need to create credentials.
 
-1. The main page for Camunda Platform 8 Console should be open on another tab. Use Camunda Platform 8 Console to navigate to your clusters either through the navigation **Clusters** or by using the section under **View all** on the **Clusters** section of the main dashboard. Click on your existing cluster. This will open the **Overview** for your cluster, where you can find your cluster id and region. You will need this information later when creating a worker in the next section.
+1. The main page for Console should be open on another tab. Use Console to navigate to your clusters either through the navigation **Clusters** or by using the section under **View all** on the **Clusters** section of the main dashboard. Click on your existing cluster. This will open the **Overview** for your cluster, where you can find your cluster id and region. You will need this information later when creating a worker in the next section.
 
 :::note 
 

--- a/docs/guides/getting-started-orchestrate-microservices.md
+++ b/docs/guides/getting-started-orchestrate-microservices.md
@@ -6,13 +6,13 @@ description: "Orchestrate Microservices along a business process for visibility 
 keywords: [microservices, orchestration, getting-started]
 ---
 
-Using Camunda Cloud, you can orchestrate the microservices necessary to achieve your end-to-end automated business process. Whether you have existing microservices or are looking to build out your microservices, this guide will help you understand how you can start your microservice orchestration journey with Camunda Cloud.
+Using Camunda Platform 8, you can orchestrate the microservices necessary to achieve your end-to-end automated business process. Whether you have existing microservices or are looking to build out your microservices, this guide will help you understand how you can start your microservice orchestration journey with Camunda Platform 8.
 
-While this guide uses code snippets in Java, you do not need to be a Java developer to be successful. Additionally, you can orchestrate microservices with Camunda Cloud in other programming languages.
+While this guide uses code snippets in Java, you do not need to be a Java developer to be successful. Additionally, you can orchestrate microservices with Camunda Platform 8 in other programming languages.
 
 ## Prerequisites
 
-* Valid Camunda Cloud account or [sign up](https://camunda.io/signup) if you still need one
+* Valid Camunda Platform 8 account or [sign up](https://camunda.io/signup) if you still need one
 * Java >= 8
 * Maven
 * IDE (IntelliJ, VSCode, or similar)
@@ -48,9 +48,9 @@ Start by designing your automated process using BPMN. This guide introduces you 
 
 ### Create credentials for your Zeebe client
 
-To interact with your Camunda Cloud cluster, you'll use the Zeebe client. First, you'll need to create credentials.
+To interact with your Camunda Platform 8 cluster, you'll use the Zeebe client. First, you'll need to create credentials.
 
-1. The main page for Camunda Cloud Console should be open on another tab. Use Camunda Cloud Console to navigate to your clusters either through the navigation **Clusters** or by using the section under **View all** on the **Clusters** section of the main dashboard. Click on your existing cluster. This will open the **Overview** for your cluster, where you can find your cluster id and region. You will need this information later when creating a worker in the next section.
+1. The main page for Camunda Platform 8 Console should be open on another tab. Use Camunda Platform 8 Console to navigate to your clusters either through the navigation **Clusters** or by using the section under **View all** on the **Clusters** section of the main dashboard. Click on your existing cluster. This will open the **Overview** for your cluster, where you can find your cluster id and region. You will need this information later when creating a worker in the next section.
 
 :::note 
 
@@ -72,9 +72,9 @@ Next, we’ll create a worker for the service task by associating it with the ty
 4. After making these changes, perform a Maven install, then run the Worker.java `main` method via your favorite IDE. If you prefer using a terminal, run `mvn package exec:java`.
 5. Using the Modeler tab in your browser, navigate to Operate and you will see your token has moved to the end event, completing this process instance.
 
-Congratulations! You successfully built your first microservice orchestration solution with Camunda Cloud.
+Congratulations! You successfully built your first microservice orchestration solution with Camunda Platform 8.
 
 ## Next steps
 
-* Learn more about Camunda Cloud and what it can do by reading [What is Camunda Cloud?](../../components/concepts/what-is-camunda-platform-8).
-* Get your local environment ready for development with Camunda Cloud by [setting up your first development project](../setting-up-development-project).
+* Learn more about Camunda Platform 8 and what it can do by reading [What is Camunda Platform 8?](../../components/concepts/what-is-camunda-platform-8).
+* Get your local environment ready for development with Camunda Platform 8 by [setting up your first development project](../setting-up-development-project).

--- a/docs/guides/getting-started/connect-to-your-cluster.md
+++ b/docs/guides/getting-started/connect-to-your-cluster.md
@@ -8,7 +8,7 @@ description: "Let's learn more about installing and communicating with clusters.
 
 ## Prerequisites
 
-- [Camunda Cloud account](create-camunda-cloud-account.md)
+- [Camunda Platform 8 account](create-camunda-cloud-account.md)
 - [Download and install Node.js and npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm)
 - Install the appropriate package:
 

--- a/docs/guides/getting-started/create-camunda-cloud-account.md
+++ b/docs/guides/getting-started/create-camunda-cloud-account.md
@@ -2,15 +2,15 @@
 id: create-camunda-cloud-account
 title: Sign up & log in
 slug: /guides/getting-started/
-description: "Set up your Camunda Cloud account to get started."
+description: "Set up your Camunda Platform 8 account to get started."
 ---
 
 <span class="badge badge--beginner">Beginner</span>
 <span class="badge badge--short">Time estimate: 5 minutes</span>
 
-## Sign up for Camunda Cloud
+## Sign up for Camunda Platform 8
 
-Create a Camunda Cloud account so you can create clusters, deploy processes, and create a new instance.
+Create a Camunda Platform 8 account so you can create clusters, deploy processes, and create a new instance.
 
 ### Visit [https://camunda.io/signup](https://camunda.io/signup)
 
@@ -26,7 +26,7 @@ If you fill out the form, you'll receive a confirmation email. Click on the link
 
 If you choose to create an account through the social sign up buttons, you'll be redirected to Console directly.
 
-## Log in to your Camunda Cloud account
+## Log in to your Camunda Platform 8 account
 
 ### Visit [https://camunda.io](https://camunda.io)
 
@@ -34,7 +34,7 @@ Log in with the email address and password you used in the previous form, or use
 
 ![login](./img/login.png)
 
-After login, you'll see the console overview page. This is the central place to manage your clusters, and the diagrams and forms you want to deploy to Camunda Cloud.
+After login, you'll see the console overview page. This is the central place to manage your clusters, and the diagrams and forms you want to deploy to Camunda Platform 8.
 
 ![overview-home](./img/home.png)
 

--- a/docs/guides/getting-started/deploy-your-process-and-start-process-instance.md
+++ b/docs/guides/getting-started/deploy-your-process-and-start-process-instance.md
@@ -12,7 +12,7 @@ description: "Deploy and start your process instance."
 
 :::note
 
-BPMN diagrams must be created for the process engine they intend to be deployed on. You cannot currently run a BPMN diagram modeled for Camunda Platform 7 in Camunda Cloud, or vice versa.
+BPMN diagrams must be created for the process engine they intend to be deployed on. You cannot currently run a BPMN diagram modeled for Camunda Platform 7 in Camunda Platform 8, or vice versa.
 :::
 
 ## Deploy and start your process instance

--- a/docs/guides/getting-started/model-your-first-process.md
+++ b/docs/guides/getting-started/model-your-first-process.md
@@ -16,7 +16,7 @@ description: "Use Modeler to design and deploy a process."
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
-In Camunda Cloud, you have two options to design and deploy a process: Web Modeler and [Desktop Modeler](https://camunda.com/download/modeler/).
+In Camunda Platform 8, you have two options to design and deploy a process: Web Modeler and [Desktop Modeler](https://camunda.com/download/modeler/).
 
 <Tabs groupId="modeler" defaultValue="web" values={
 [

--- a/docs/guides/getting-started/monitor-your-process-in-operate.md
+++ b/docs/guides/getting-started/monitor-your-process-in-operate.md
@@ -1,7 +1,7 @@
 ---
 id: monitor-your-process-in-operate
 title: Monitor your process in Operate
-description: "Camunda Cloud offers Operate to monitor your process instances."
+description: "Camunda Platform 8 offers Operate to monitor your process instances."
 ---
 <span class="badge badge--beginner">Beginner</span>
 <span class="badge badge--short">Time estimate: 8 minutes</span>
@@ -15,7 +15,7 @@ description: "Camunda Cloud offers Operate to monitor your process instances."
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Camunda Cloud offers Operate to monitor your process instances.
+Camunda Platform 8 offers Operate to monitor your process instances.
 
 :::note
 Find an entry point in the cluster details.

--- a/docs/guides/getting-started/setup-client-connection-credentials.md
+++ b/docs/guides/getting-started/setup-client-connection-credentials.md
@@ -8,7 +8,7 @@ description: "Set up client connection credentials to create, name, and connect 
 
 ## Prerequisites
 
-- [Camunda Cloud account](create-camunda-cloud-account.md)
+- [Camunda Platform 8 account](create-camunda-cloud-account.md)
 
 ## Set up client connection credentials
 

--- a/docs/guides/improve-processes-with-optimize.md
+++ b/docs/guides/improve-processes-with-optimize.md
@@ -19,10 +19,10 @@ See an in-depth overview of Optimize’s capabilities [here](https://docs.camund
 
 ## Set up
 
-Within Camunda Cloud, you can launch Optimize from the Cloud Console — the interface where you can create clusters, and launch both Operate and Tasklist. Therefore, ensure you’ve [created a Camunda Cloud account](./getting-started/create-camunda-cloud-account.md), [set up client connection credentials](./getting-started/setup-client-connection-credentials.md), and [connected to your cluster](./getting-started/connect-to-your-cluster.md) before getting started with Optimize for SaaS users.
+Within Camunda Platform 8, you can launch Optimize from the Cloud Console — the interface where you can create clusters, and launch both Operate and Tasklist. Therefore, ensure you’ve [created a Camunda Platform 8 account](./getting-started/create-camunda-cloud-account.md), [set up client connection credentials](./getting-started/setup-client-connection-credentials.md), and [connected to your cluster](./getting-started/connect-to-your-cluster.md) before getting started with Optimize for SaaS users.
 
 :::note
-So long as you are operating with [Camunda Cloud 1.2+](https://camunda.com/blog/2021/10/camunda-cloud-1-2-0-released/) when creating a cluster, you can access Optimize. From here, Optimize requires no additional set up. You can immediately obtain process insights as Optimize already continuously collects data for analysis.
+So long as you are operating with [Camunda Platform 8 1.2+](https://camunda.com/blog/2021/10/camunda-cloud-1-2-0-released/) when creating a cluster, you can access Optimize. From here, Optimize requires no additional set up. You can immediately obtain process insights as Optimize already continuously collects data for analysis.
 :::
 
 Once you’ve created a cluster, take the following steps inside Cloud Console to access Optimize:

--- a/docs/guides/improve-processes-with-optimize.md
+++ b/docs/guides/improve-processes-with-optimize.md
@@ -19,13 +19,13 @@ See an in-depth overview of Optimize’s capabilities [here](https://docs.camund
 
 ## Set up
 
-Within Camunda Platform 8, you can launch Optimize from the Cloud Console — the interface where you can create clusters, and launch both Operate and Tasklist. Therefore, ensure you’ve [created a Camunda Platform 8 account](./getting-started/create-camunda-cloud-account.md), [set up client connection credentials](./getting-started/setup-client-connection-credentials.md), and [connected to your cluster](./getting-started/connect-to-your-cluster.md) before getting started with Optimize for SaaS users.
+Within Camunda Platform 8, you can launch Optimize from Console — the interface where you can create clusters, and launch both Operate and Tasklist. Therefore, ensure you’ve [created a Camunda Platform 8 account](./getting-started/create-camunda-cloud-account.md), [set up client connection credentials](./getting-started/setup-client-connection-credentials.md), and [connected to your cluster](./getting-started/connect-to-your-cluster.md) before getting started with Optimize for SaaS users.
 
 :::note
 So long as you are operating with [Camunda Platform 8 1.2+](https://camunda.com/blog/2021/10/camunda-cloud-1-2-0-released/) when creating a cluster, you can access Optimize. From here, Optimize requires no additional set up. You can immediately obtain process insights as Optimize already continuously collects data for analysis.
 :::
 
-Once you’ve created a cluster, take the following steps inside Cloud Console to access Optimize:
+Once you’ve created a cluster, take the following steps inside Console to access Optimize:
 
 1. Click the **Clusters** tab and select the cluster you’d like to analyze.
 2. Click the **Applications** tab.

--- a/docs/guides/introduction-to-camunda-cloud.md
+++ b/docs/guides/introduction-to-camunda-cloud.md
@@ -13,7 +13,7 @@ Camunda Platform 8 is comprised of six components:
 * Operate - Manage, monitor, and troubleshoot your processes through Operate.
 * Optimize - Improve your processes by identifying constraints in your system with Optimize.
 * Tasklist - Use Tasklist to complete tasks which need human input.
-* Cloud Console - Configure and deploy clusters with Cloud Console.
+* Console - Configure and deploy clusters with Console.
 * Web Modeler - Collaborate and model processes, deploy and start new instances all without leaving Camunda Platform 8.
 
 Camunda Platform 8 can be used with both Desktop Modeler, and Web Modeler.

--- a/docs/guides/introduction-to-camunda-cloud.md
+++ b/docs/guides/introduction-to-camunda-cloud.md
@@ -1,25 +1,25 @@
 ---
 id: introduction-to-camunda-cloud
-title: Introduction to Camunda Cloud
-sidebar_label: Introduction to Camunda Cloud
+title: Introduction to Camunda Platform 8
+sidebar_label: Introduction to Camunda Platform 8
 slug: /guides/
 ---
 
-[Camunda Cloud](https://camunda.io) delivers scalable, on-demand process automation as-a-service. Camunda Cloud is combined with powerful execution engines for BPMN processes and DMN decisions, and paired with tools for collaborative modeling, operations, and analytics.
+[Camunda Platform 8](https://camunda.io) delivers scalable, on-demand process automation as-a-service. Camunda Platform 8 is combined with powerful execution engines for BPMN processes and DMN decisions, and paired with tools for collaborative modeling, operations, and analytics.
 
-Camunda Cloud is comprised of six components:
+Camunda Platform 8 is comprised of six components:
 
-* Zeebe - Zeebe is the cloud-native process engine of Camunda Cloud.
+* Zeebe - Zeebe is the cloud-native process engine of Camunda Platform 8.
 * Operate - Manage, monitor, and troubleshoot your processes through Operate.
 * Optimize - Improve your processes by identifying constraints in your system with Optimize.
 * Tasklist - Use Tasklist to complete tasks which need human input.
 * Cloud Console - Configure and deploy clusters with Cloud Console.
-* Web Modeler - Collaborate and model processes, deploy and start new instances all without leaving Camunda Cloud.
+* Web Modeler - Collaborate and model processes, deploy and start new instances all without leaving Camunda Platform 8.
 
-Camunda Cloud can be used with both Desktop Modeler, and Web Modeler.
+Camunda Platform 8 can be used with both Desktop Modeler, and Web Modeler.
 
-In this section of the Camunda Cloud documentation, you'll find guides for getting started with Camunda Cloud. For more conceptual information on Camunda Cloud, see [What is Camunda Cloud](components/concepts/what-is-camunda-platform-8.md).
+In this section of the Camunda Platform 8 documentation, you'll find guides for getting started with Camunda Platform 8. For more conceptual information on Camunda Platform 8, see [What is Camunda Platform 8](components/concepts/what-is-camunda-platform-8.md).
 
 ## Next steps
 
-- [Sign up and log in to Camunda Cloud](/guides/getting-started/create-camunda-cloud-account.md)
+- [Sign up and log in to Camunda Platform 8](/guides/getting-started/create-camunda-cloud-account.md)

--- a/docs/guides/message-correlation.md
+++ b/docs/guides/message-correlation.md
@@ -14,7 +14,7 @@ description: "Message correlation allows you to target a running workflow with a
 
 ## Message correlation
 
-Message correlation is a powerful feature in Camunda Cloud. It allows you to target a running workflow with a state update from an external system asynchronously. 
+Message correlation is a powerful feature in Camunda Platform 8. It allows you to target a running workflow with a state update from an external system asynchronously. 
 
 This tutorial uses the [Node.js client](https://github.com/camunda-community-hub/zeebe-client-node-js), but it serves to illustrate message correlation concepts that are applicable to all language clients.
 
@@ -22,7 +22,7 @@ We will use [Simple Monitor](https://github.com/camunda-community-hub/zeebe-simp
 
 ## Workflow
 
-Here is a basic example from [the Camunda Cloud documentation](/components/concepts/messages.md):
+Here is a basic example from [the Camunda Platform 8 documentation](/components/concepts/messages.md):
 
 ![message correlation workflow](img/message-correlation-workflow.png)
 
@@ -183,6 +183,6 @@ A couple of common gotchas:
 
 ## Summary
 
-Message Correlation is a powerful feature in Camunda Cloud. Knowing how messages are correlated, and how and when the message subscription is created is important to design systems that perform as expected.
+Message Correlation is a powerful feature in Camunda Platform 8. Knowing how messages are correlated, and how and when the message subscription is created is important to design systems that perform as expected.
 
-Simple Monitor is a useful tool for inspecting the behavior of a local Camunda Cloud system to figure out what is happening during development.
+Simple Monitor is a useful tool for inspecting the behavior of a local Camunda Platform 8 system to figure out what is happening during development.

--- a/docs/guides/operating-the-camunda-cloud-stack-on-kubernetes.md
+++ b/docs/guides/operating-the-camunda-cloud-stack-on-kubernetes.md
@@ -1,6 +1,6 @@
 ---
 id: operating-the-camunda-cloud-stack-on-kubernetes
-title: Operate the Camunda Cloud stack on Kubernetes
+title: Operate the Camunda Platform 8 stack on Kubernetes
 ---
 
 ...

--- a/docs/guides/setting-up-development-project.md
+++ b/docs/guides/setting-up-development-project.md
@@ -9,7 +9,7 @@ keywords: [get-started, local-install]
 
 ## Prerequisites
 
-- [Camunda Cloud SaaS](https://camunda.io)
+- [Camunda Platform 8 SaaS](https://camunda.io)
 - [Desktop Modeler](https://camunda.com/download/modeler/)
 - [Operate](/self-managed/operate-deployment/install-and-start.md)
 - [Tasklist](/self-managed/tasklist-deployment/install-and-start.md)
@@ -20,7 +20,7 @@ keywords: [get-started, local-install]
 Let's set up your first project to model, deploy, and start a process instance.
 
 The [camunda-cloud-get-started GitHub repository](https://github.com/camunda-cloud/camunda-cloud-get-started)
-contains a hands-on guide for setting up a Camunda Cloud project locally.
+contains a hands-on guide for setting up a Camunda Platform 8 project locally.
 
 The guide offers a general walk-through on how to model, deploy, and start a
 process instance. It also includes code examples on how to connect to the

--- a/docs/guides/update-guide/introduction.md
+++ b/docs/guides/update-guide/introduction.md
@@ -3,33 +3,37 @@ id: introduction
 title: Introduction
 ---
 
-These documents guide you through the process of updating your Camunda Cloud
-application or server installation from one Camunda Cloud version to the other.
+These documents guide you through the process of updating your Camunda Platform 8
+application or server installation from one Camunda Platform 8 version to the other.
+
+:::note
+Versions prior to Camunda Platform 8 are listed below and identified as Camunda Cloud versions.
+:::
 
 There is a dedicated update guide for each version:
 
-### [1.2 to 1.3](../120-to-130)
+### [Camunda Cloud 1.2 to 1.3](../120-to-130)
 
 Update from 1.2.x to 1.3.0
 
 [Release notes](https://github.com/camunda-cloud/zeebe/releases/tag/1.3.0)
 [Release blog](https://camunda.com/blog/2022/01/camunda-cloud-1-3-0-released/)
 
-### [1.1 to 1.2](../110-to-120)
+### [Camunda Cloud 1.1 to 1.2](../110-to-120)
 
 Update from 1.1.x to 1.2.0
 
 [Release notes](https://github.com/camunda-cloud/zeebe/releases/tag/1.2.0)
 [Release blog](https://camunda.com/blog/2021/10/camunda-cloud-1-2-0-released/)
 
-### [1.0 to 1.1](../100-to-110)
+### [Camunda Cloud 1.0 to 1.1](../100-to-110)
 
 Update from 1.0.x to 1.1.0
 
 [Release notes](https://github.com/camunda-cloud/zeebe/releases/tag/1.1.0)
 [Release blog](https://camunda.com/blog/2021/07/camunda-cloud-110-released/)
 
-### [0.26 to 1.0](../026-to-100)
+### [Camunda Cloud 0.26 to 1.0](../026-to-100)
 
 Update from 0.26.x to 1.0.0
 

--- a/docs/guides/utilizing-forms.md
+++ b/docs/guides/utilizing-forms.md
@@ -14,13 +14,13 @@ If using with Camunda Platform 7, note that the Camunda Forms feature was added 
 
 The Camunda Forms feature allows you to easily design and configure forms. Once configured, they can be connected to a user task or start event to implement a task form in your application.
 
-While you can incorporate Camunda Forms solely within Camunda Cloud, you can also utilize Camunda Forms in Camunda Platform 7. After deploying a diagram with an embedded form, Tasklist imports this form schema and uses it to render the form on every task assigned to it.
+While you can incorporate Camunda Forms solely within Camunda Platform 8, you can also utilize Camunda Forms in Camunda Platform 7. After deploying a diagram with an embedded form, Tasklist imports this form schema and uses it to render the form on every task assigned to it.
 
 ## Quickstart
 
 ### Create new form
 
-To start building a form, log in to your [Camunda Cloud](./getting-started/create-camunda-cloud-account.md) account or open [Desktop Modeler](./components/modeler/about.md) and take the following steps:
+To start building a form, log in to your [Camunda Platform 8](./getting-started/create-camunda-cloud-account.md) account or open [Desktop Modeler](./components/modeler/about.md) and take the following steps:
 
 1. Click on the **Modeler** tab at the top of the page or alternatively open the **File** menu in Desktop Modeler.
 2. Open any project from your Web Modeler home view.
@@ -50,7 +50,7 @@ Refer to the [Camunda Forms reference material](../components/modeler/forms/camu
 
 ### Save your form
 
-To save your form in Camunda Cloud, you don't have to do anything. Web Modeler will autosave every change you make.
+To save your form in Camunda Platform 8, you don't have to do anything. Web Modeler will autosave every change you make.
 
 To save your form in Camunda Platform 7, click **File > Save File As...** in the top-level menu. Select a location on your file system to store the form as `.form` file. You can load that file again by clicking **File > Open File...**.
 


### PR DESCRIPTION
Camunda Cloud to Camunda Platform 8.

In `/guides/update-guide/*` I did not do a rename because these versions are theoretically part of Camunda Cloud. If that's incorrect, let me know and we can adjust. It just felt odd to call something "Camunda Platform 8 1.2" 😆 