### PR TITLE
Add Micronaut to list of community clients

### DIFF
--- a/docs/apis-clients/overview.md
+++ b/docs/apis-clients/overview.md
@@ -45,6 +45,7 @@ Community clients supplement the official clients. These clients have not been t
 
 - [C#](community-clients/c-sharp.md)
 - [JavaScript/NodeJS](community-clients/javascript.md)
+- [Micronaut](community-clients/micronaut.md)
 - [Python](community-clients/python.md)
 - [Ruby](community-clients/ruby.md)
 - [Rust](community-clients/rust.md)


### PR DESCRIPTION
I'm the lead developer of the Micronaut Zeebe Client. Please add "Micronaut" to the list of community clients, see PR.

Actually, I'm also missing "Micronaut" in the sidebar (see screenshot). I'm not sure if this PR will fix that as well - probably not. Would be nice if you could add that as well.

![image](https://user-images.githubusercontent.com/5685151/163156464-fcdd1dc3-3eff-4139-8458-ac5e2315807a.png)
