### PR TITLE
style(navbar): scale navbar items down in resolutions between mobile and desktop

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -3,7 +3,7 @@ name: build-docs
 on:
   push:
     branches:
-      - "**""
+      - "**"
       - "!master"
     tags-ignore:
       - "*"

--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -3,7 +3,7 @@ name: build-docs
 on:
   push:
     branches:
-      - "*"
+      - "**""
       - "!master"
     tags-ignore:
       - "*"

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -202,6 +202,22 @@ navbar .navbar .navbar__link[href*=self-managed] {
   margin-right: 2px;
 }
 
+/* Between mobile and desktop sizes, the nav bar gets a little scrunchy. Scale things down a bit to make more space. */ 
+@media screen and (min-width: 996px) and (max-width: 1140px) {
+  .navbar .navbar__title, .navbar .navbar__link {
+    font-size: 0.9em;
+  }
+
+  .navbar .navbar__item {
+    padding: var(--ifm-navbar-item-padding-vertical) calc(0.5 * var(--ifm-navbar-item-padding-horizontal));
+  }
+
+  .navbar .navbar__link[href*=self-managed]:before {
+    width: 23px;
+    height: 23px;
+  }  
+}
+
 .get-started-use-case {
   background-color:#042B1D;
   color: #fff;


### PR DESCRIPTION
This PR scales down the size of navbar items at screen resolutions larger than mobile (996px) but smaller than most desktops (~1140px). "Scaling down" includes slightly reducing the font-size, horizontal padding, and size of the "self-managed" icon: 

https://user-images.githubusercontent.com/1627089/163476930-b5df483b-617f-459f-bdc0-a851eac5ce49.mov

## Why? 

At screen resolutions on the small side of desktop, but larger than the mobile breakpoint, the navbar items get a bit scrunchy and unpleasant: 

<img width="1003" alt="image" src="https://user-images.githubusercontent.com/1627089/163472661-db4b5f53-565c-49d5-b6d5-b30b2dc0c09a.png">


## More details

- The specific resolutions affected are 996px to ~1140px. At 996 and smaller, the "mobile" nav menu shows, which makes this problem go away. At 1140px and above, there's enough space available that items aren't forced to wrap. 

- The self-managed icon was reduced in size because at its original size, it caused the "Self-Managed" text to be misaligned from the remaining items. 

- Docusaurus [chooses between rendering the mobile vs desktop nav in React, not CSS, via a `useWindowSize` hook](https://github.com/facebook/docusaurus/blob/2e79597f83f93abbdeb9434dda2b3bd796882717/packages/docusaurus-theme-common/src/contexts/navbarMobileSidebar.tsx#L52). The `useWindowSize` hook [references a specific hard-coded width as the threshold](https://github.com/facebook/docusaurus/blob/main/packages/docusaurus-theme-common/src/hooks/useWindowSize.ts#L20). There is no available method to override this value. 

## Alternatives considered

1. Work with Docusaurus to implement a way to customize the width when the mobile vs desktop navigation displays. This seems like a good amount of work, and time-consuming. Maybe a good long-term solution, but not something that would happen any time soon. 
2. Use [`patch-package`][patch-package] to override the logic in Docusaurus that chooses to display the mobile or desktop navigation. This would be a relatively small amount of effort up front, but there's a long tail -- it'd require adding a git hook to apply the patch at the right time locally, an addition to the build process to patch the package, and the risk whenever we updated the docusaurus dependency of either breaking or failing silently. 
3. Hide an item in the navbar in this in-between state. The difficulty here is choosing which one to hide. I don't know enough about the docs to know if there is a reasonable candidate for this. I suspect there is not, because if we just hide it, it doesn't show up anywhere else, and that seems bad. 

[patch-package]: https://github.com/ds300/patch-package