### PR TITLE
style(features): scale feature icons down a bit

### DIFF
--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -32,6 +32,6 @@
 }
 
 .featureImage {
-  height: 200px;
-  width: 200px;
+  height: 130px;
+  width: 130px;
 }


### PR DESCRIPTION
Addresses #817 

The source images for the feature icons are 150x150. They were previously displaying as 200x200, resulting in some low-res stretchiness. This PR scales them down, displaying them as slightly smaller than the sources (130x130) to better align with the proposed UI from marketing (which can be found in the slack conversation linked below). 

There is still a slight bit of blurriness to the icons, the edges don't seem totally sharp. My interpretation is that they were built that way intentionally, but if people still find it unsettling I can push for marketing to make new images with sharper edges. 

Before:

<img width="1504" alt="image" src="https://user-images.githubusercontent.com/1627089/163596585-f6f9964b-5b26-441b-9fa3-783954023a5c.png">

After: 

<img width="1495" alt="image" src="https://user-images.githubusercontent.com/1627089/163596469-6ba39b5a-4904-42f3-aa2f-9bfefe8effde.png">

See [this thread](https://camunda.slack.com/archives/C01UMP0V17Z/p1649780222187189) for history. 

I've added reviewers based on the original slack conversation, with intention to self-merge when I receive positive-or-neutral feedback. 