### PR TITLE
docs(branding): replace broken logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-<img src="./static/img/camunda-cloud-gradient.png" width="200px"/>
+<img src="./static/img/black-C.png" width="200px"/>
 
 <h1>Camunda Cloud Documentation</h1>
 <p>


### PR DESCRIPTION
Addresses #813 

Replaces the previously broken brand logo with a new one: 

<img width="1292" alt="image" src="https://user-images.githubusercontent.com/1627089/163623353-d641aa90-2bf5-4a0a-9f44-457ba33ea84d.png">
