### PR TITLE
chore(format): exclude build artifacts from prettier

### DIFF
--- a/.github/workflows/publish-c8.yaml
+++ b/.github/workflows/publish-c8.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Disable Indexing
         run: "sed -i 's/noIndex: false/noIndex: true/g' docusaurus.config.js"
       - name: Update URL
-        run: "sed -i 's!url: \"https://docs.camunda.io\"!url: \"https://c8.docs.camunda.io\"!g' docusaurus.config.js"
+        run: 'sed -i ''s!url: "https://docs.camunda.io"!url: "https://c8.docs.camunda.io"!g'' docusaurus.config.js'
       - name: Build
         run: npm run build
       - name: Publish

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,6 +8,10 @@ package-lock.json
 # Ignore files managed by VSCode
 .vscode
 
+# Ignore build artifacts
+.docusaurus
+build
+
 # -------- To be removed -------- #
 # Ignore while prettier is being  #
 # enabled to assist gradual       #


### PR DESCRIPTION
1. Adds two build artifact folders to the .prettierignore. They are generated by docusaurus, and excluded from git, and not worth us spending time formatting. 
2. Updates the formatting for a github action

This work is a follow-up to #815. @korthout noticed those folders being formatted in that PR, but we fixed it here in a follow-up for ease of PR review. 
