### PR TITLE
Add Micronaut to list of community clients

### DIFF
--- a/docs/apis-clients/overview.md
+++ b/docs/apis-clients/overview.md
@@ -45,6 +45,7 @@ Community clients supplement the official clients. These clients have not been t
 
 - [C#](community-clients/c-sharp.md)
 - [JavaScript/NodeJS](community-clients/javascript.md)
+- [Micronaut](community-clients/micronaut.md)
 - [Python](community-clients/python.md)
 - [Ruby](community-clients/ruby.md)
 - [Rust](community-clients/rust.md)


### PR DESCRIPTION
Adding Micronaut to https://docs.camunda.io/docs/apis-clients/overview/