### PR TITLE
docs(getting-started): remove connect to your cluster page from sidebars

### DIFF
--- a/docs/guides/getting-started/setup-client-connection-credentials.md
+++ b/docs/guides/getting-started/setup-client-connection-credentials.md
@@ -35,7 +35,3 @@ The downloaded file contains all the necessary information to communicate with y
 - `ZEEBE_ADDRESS`: Address where your cluster can be reached.
 - `ZEEBE_CLIENT_ID` and `ZEEBE_CLIENT_SECRET`: Credentials to request a new access token.
 - `ZEEBE_AUTHORIZATION_SERVER_URL`: A new token can be requested at this address, using the credentials.
-
-## Next steps
-
-- [Connect to your cluster](connect-to-your-cluster.md)

--- a/docs/guides/improve-processes-with-optimize.md
+++ b/docs/guides/improve-processes-with-optimize.md
@@ -19,7 +19,7 @@ For an in-depth overview of Optimize’s capabilities, visit our [Optimize docum
 
 ## Set up
 
-Within Camunda Platform 8, you can launch Optimize from Console — the interface where you can create clusters, and launch both Operate and Tasklist. Therefore, ensure you’ve [created a Camunda Platform 8 account](./getting-started/create-camunda-cloud-account.md), [set up client connection credentials](./getting-started/setup-client-connection-credentials.md), and [connected to your cluster](./getting-started/connect-to-your-cluster.md) before getting started with Optimize for SaaS users.
+Within Camunda Platform 8, you can launch Optimize from Console — the interface where you can create clusters, and launch both Operate and Tasklist. Therefore, ensure you’ve [created a Camunda Platform 8 account](./getting-started/create-camunda-cloud-account.md) and [set up client connection credentials](./getting-started/setup-client-connection-credentials.md) before getting started with Optimize for SaaS users.
 
 :::note
 So long as you are operating with [Camunda Platform 8 1.2+](https://camunda.com/blog/2021/10/camunda-cloud-1-2-0-released/) when creating a cluster, you can access Optimize. From here, Optimize requires no additional set up. You can immediately obtain process insights as Optimize already continuously collects data for analysis.

--- a/sidebars.js
+++ b/sidebars.js
@@ -6,7 +6,7 @@ module.exports = {
         "guides/getting-started/create-camunda-cloud-account",
         "guides/getting-started/create-your-cluster",
         "guides/getting-started/setup-client-connection-credentials",
-        "guides/getting-started/connect-to-your-cluster",
+        // "guides/getting-started/connect-to-your-cluster",
         "guides/getting-started/model-your-first-process",
         "guides/getting-started/deploy-your-process-and-start-process-instance",
         "guides/getting-started/implement-service-task",


### PR DESCRIPTION
Quick fix for part of #838 